### PR TITLE
feature: add dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,20 @@
+version: 2
+updates:
+  - package-ecosystem: "cargo"
+    directory: "/"
+    schedule:
+      interval: "daily"
+      time: "04:00" # UTC
+    labels:
+      - "dependencies"
+    commit-message:
+      prefix: "bump"
+    open-pull-requests-limit: 10
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    labels:
+      - "dependencies"
+    commit-message:
+      prefix: "chore(ci)"


### PR DESCRIPTION
Adds https://github.com/dependabot to this repository to ensure latest versions of crates.