### PR TITLE
refactor: move to clap

### DIFF
--- a/crates/rattler/Cargo.toml
+++ b/crates/rattler/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 
 [dependencies]
 anyhow = "1.0.44"
-structopt = "0.3.25"
+clap = { version="3.2.14", features=["derive"] }
 tokio = { version = "1.12.0", features = ["full", "io-util"] }
 tokio-util = { version = "0.7.3", features = ["codec"] }
 futures = "0.3.17"

--- a/crates/rattler/src/commands/create.rs
+++ b/crates/rattler/src/commands/create.rs
@@ -9,7 +9,6 @@ use pubgrub::solver::resolve;
 use reqwest_middleware::ClientBuilder;
 use reqwest_retry::policies::ExponentialBackoff;
 use reqwest_retry::RetryTransientMiddleware;
-use structopt::StructOpt;
 use thiserror::Error;
 use tokio::spawn;
 
@@ -18,12 +17,12 @@ use rattler::{
     RepoData, SolverIndex, Version,
 };
 
-#[derive(Debug, StructOpt)]
+#[derive(Debug, clap::Parser)]
 pub struct Opt {
-    #[structopt(short)]
+    #[clap(short)]
     channels: Option<Vec<String>>,
 
-    #[structopt(required = true)]
+    #[clap(required = true)]
     specs: Vec<String>,
 }
 

--- a/crates/rattler/src/main.rs
+++ b/crates/rattler/src/main.rs
@@ -1,16 +1,17 @@
-use structopt::StructOpt;
+use clap::Parser;
 
 mod commands;
 
 /// Command line options available through the `rattler` cli.
-#[derive(Debug, StructOpt)]
+#[derive(Debug, Parser)]
+#[clap(author, version, about, long_about = None)]
 struct Opt {
-    #[structopt(subcommand)]
+    #[clap(subcommand)]
     command: Command,
 }
 
 /// Different commands supported by `rattler`.
-#[derive(Debug, StructOpt)]
+#[derive(Debug, clap::Subcommand)]
 enum Command {
     Create(commands::create::Opt),
 }
@@ -20,7 +21,7 @@ enum Command {
 async fn main() -> anyhow::Result<()> {
     pretty_env_logger::init();
 
-    let opt = Opt::from_args();
+    let opt = Opt::parse();
     match opt.command {
         Command::Create(opt) => commands::create::create(opt).await,
     }


### PR DESCRIPTION
Moves from `structopt` to latest version of `clap`