### PR TITLE
feat(ci): build on pull_request or push to main

### DIFF
--- a/.github/workflows/rust-compile.yml
+++ b/.github/workflows/rust-compile.yml
@@ -54,7 +54,6 @@ jobs:
           args: --all -- --check
 
   clippy:
-    name: Clippy
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -63,8 +62,8 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-      - run: rustup component add clippy
-      - uses: actions-rs/cargo@v1
+          components: clippy
+      - uses: actions-rs/clippy-check@v1
         with:
-          command: clippy
-          args: -- -D warnings
+          token: ${{ secrets.GITHUB_TOKEN }}
+          args: --all-features -- -D warnings

--- a/.github/workflows/rust-compile.yml
+++ b/.github/workflows/rust-compile.yml
@@ -1,4 +1,7 @@
-on: [push, pull_request]
+on:
+  push:
+    branches: [ $default-branch ]
+  pull_request:
 
 name: Continuous integration
 

--- a/.github/workflows/rust-compile.yml
+++ b/.github/workflows/rust-compile.yml
@@ -11,6 +11,7 @@ concurrency:
 
 env:
   RUSTFLAGS: -Dwarnings
+  CARGO_TERM_COLOR: always
 
 jobs:
   check:

--- a/.github/workflows/rust-compile.yml
+++ b/.github/workflows/rust-compile.yml
@@ -5,6 +5,10 @@ on:
 
 name: Continuous integration
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   RUSTFLAGS: -Dwarnings
 

--- a/.github/workflows/rust-compile.yml
+++ b/.github/workflows/rust-compile.yml
@@ -29,7 +29,15 @@ jobs:
 
   test:
     name: Test Suite
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    needs: check
+    strategy:
+      fail-fast: false
+      matrix:
+        os: ["ubuntu-latest", "windows-latest", "macOS-latest"]
+        include:
+          - os: "windows-latest"
+            RUSTFLAGS: "$RUSTFLAGS -Ctarget-feature=+crt-static"
     steps:
       - uses: actions/checkout@v3
         with:

--- a/crates/rattler/src/platform.rs
+++ b/crates/rattler/src/platform.rs
@@ -47,8 +47,15 @@ impl Platform {
             #[cfg(not(any(target_arch = "x86_64", target_arch = "x86")))]
             compile_error!("unsupported windows architecture");
         }
+        #[cfg(target_os = "macos")]
+        {
+            #[cfg(target_arch = "x86_64")]
+            return Platform::Osx64;
 
-        #[cfg(not(any(target_os = "linux", windows)))]
+            #[cfg(target_arch = "aarch64")]
+            return Platform::OsxArm64;
+        }
+        #[cfg(not(any(target_os = "linux", target_os = "macos", windows)))]
         compile_error!("unsupported target os");
     }
 


### PR DESCRIPTION
Some CI improvements:

* Only build when pushing to default branch *or* for pull_requests.
* Use [`clippy-check`](https://github.com/actions-rs/clippy-check) for clippy to get better output in log.
* Cancel previous running CI job if new commits are pushed
* Adds a build matrix to build on all supported platforms
* Ensures cargo always outputs colors
* Fix an issue with MacOS builds!