### PR TITLE
feat: sync extraction of existing package formats

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,3 @@
 **/repodata.json filter=lfs diff=lfs merge=lfs -text
 *.conda filter=lfs diff=lfs merge=lfs -text
+*.tar.bz2 filter=lfs diff=lfs merge=lfs -text

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,2 @@
 **/repodata.json filter=lfs diff=lfs merge=lfs -text
+*.conda filter=lfs diff=lfs merge=lfs -text

--- a/crates/rattler_package_streaming/Cargo.toml
+++ b/crates/rattler_package_streaming/Cargo.toml
@@ -11,14 +11,10 @@ repository = "https://github.com/baszalmstra/rattler"
 [dependencies]
 async-trait = "0.1.59"
 thiserror = "1.0.37"
-tar = { version = "0.4.38", optional = true }
-bzip2-rs = { version = "0.1.2", git = "https://github.com/paolobarbolini/bzip2-rs", features = ["rustc_1_55"], optional = true }
-zip = { version = "0.6.3", optional = true }
+tar = { version = "0.4.38" }
+bzip2 = { version = "0.4" }
+zip = { version = "0.6.3" }
 zstd = "0.12.1"
 
 [features]
-default = ["sync", "rayon"]
-sync = ["tar", "zip", "bzip2-rs", "zip"]
-async = []
-rayon = ["bzip2-rs/rayon"]
-
+tokio = ["bzip2/tokio"]

--- a/crates/rattler_package_streaming/Cargo.toml
+++ b/crates/rattler_package_streaming/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "rattler_package_streaming"
+version = "0.1.0"
+edition = "2021"
+authors = ["Bas Zalmstra <zalmstra.bas@gmail.com>"]
+description = "Extract and stream of Conda package archives"
+categories = ["conda"]
+homepage = "https://github.com/baszalmstra/rattler"
+repository = "https://github.com/baszalmstra/rattler"
+
+[dependencies]
+async-trait = "0.1.59"
+thiserror = "1.0.37"
+tar = { version = "0.4.38", optional = true }
+bzip2-rs = { version = "0.1.2", git = "https://github.com/paolobarbolini/bzip2-rs", features = ["rustc_1_55"], optional = true }
+zip = { version = "0.6.3", optional = true }
+zstd = "0.12.1"
+
+[features]
+default = ["sync", "rayon"]
+sync = ["tar", "zip", "bzip2-rs", "zip"]
+async = []
+rayon = ["bzip2-rs/rayon"]
+

--- a/crates/rattler_package_streaming/data/conda-22.11.1-py38haa244fe_1.conda
+++ b/crates/rattler_package_streaming/data/conda-22.11.1-py38haa244fe_1.conda
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a8a44c5ff2b2f423546d49721ba2e3e632233c74a813c944adf8e5742834930e
+size 928900

--- a/crates/rattler_package_streaming/data/conda-22.9.0-py38haa244fe_2.tar.bz2
+++ b/crates/rattler_package_streaming/data/conda-22.9.0-py38haa244fe_2.tar.bz2
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3c2c2e8e81bde5fb1ac4b014f51a62411feff004580c708c97a0ec2b7058cdc4
+size 1005971

--- a/crates/rattler_package_streaming/data/mamba-1.0.0-py38hecfeebb_2.tar.bz2
+++ b/crates/rattler_package_streaming/data/mamba-1.0.0-py38hecfeebb_2.tar.bz2
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f44c4bc9c6916ecc0e33137431645b029ade22190c7144eead61446dcbcc6f97
+size 66913

--- a/crates/rattler_package_streaming/data/mamba-1.1.0-py39hb3d9227_2.conda
+++ b/crates/rattler_package_streaming/data/mamba-1.1.0-py39hb3d9227_2.conda
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c172acdf9cb7655dd224879b30361a657b09bb084b65f151e36a2b51e51a080a
+size 64785

--- a/crates/rattler_package_streaming/data/micromamba-1.1.0-0.tar.bz2
+++ b/crates/rattler_package_streaming/data/micromamba-1.1.0-0.tar.bz2
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5a1e1fe69a301e817cf2795ace03c9e4a42e97cd8984b6edbc8872dad00d5097
+size 3720234

--- a/crates/rattler_package_streaming/data/mujoco-2.3.1-ha3edaa6_0.conda
+++ b/crates/rattler_package_streaming/data/mujoco-2.3.1-ha3edaa6_0.conda
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:007f27a98a150ac3fbbd5bdd708d35f807ba2e117a194f218b130890d461ce77
+size 16303

--- a/crates/rattler_package_streaming/data/pytweening-1.0.4-pyhd8ed1ab_0.tar.bz2
+++ b/crates/rattler_package_streaming/data/pytweening-1.0.4-pyhd8ed1ab_0.tar.bz2
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:81644bcb60d295f7923770b41daf2d90152ef54b9b094c26513be50fccd62125
+size 10027

--- a/crates/rattler_package_streaming/data/ros-noetic-rosbridge-suite-0.11.14-py39h6fdeb60_14.tar.bz2
+++ b/crates/rattler_package_streaming/data/ros-noetic-rosbridge-suite-0.11.14-py39h6fdeb60_14.tar.bz2
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4dd9893f1eee45e1579d1a4f5533ef67a84b5e4b7515de7ed0db1dd47adc6bc8
+size 6061

--- a/crates/rattler_package_streaming/data/ruff-0.0.171-py310h298983d_0.conda
+++ b/crates/rattler_package_streaming/data/ruff-0.0.171-py310h298983d_0.conda
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:25c755b97189ee066576b4ae3999d5e7ff4406d236b984742194e63941838dcd
+size 2168157

--- a/crates/rattler_package_streaming/data/stir-5.0.2-py38h9224444_7.conda
+++ b/crates/rattler_package_streaming/data/stir-5.0.2-py38h9224444_7.conda
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:352fe747f7f09b09baa4b6561485b3f0d4271f6f798d34dae7116c3c9c6ba896
+size 64995299

--- a/crates/rattler_package_streaming/src/lib.rs
+++ b/crates/rattler_package_streaming/src/lib.rs
@@ -5,6 +5,9 @@ use std::path::Path;
 #[cfg(feature = "sync")]
 pub mod read;
 
+#[cfg(feature = "sync")]
+pub mod seek;
+
 /// An error that can occur when extracting a package archive.
 #[derive(thiserror::Error, Debug)]
 pub enum ExtractError {
@@ -16,6 +19,12 @@ pub enum ExtractError {
 
     #[error("invalid zip archive")]
     ZipError(#[from] zip::result::ZipError),
+
+    #[error("a component is missing from the Conda archive")]
+    MissingComponent,
+
+    #[error("unsupported compression method")]
+    UnsupportedCompressionMethod,
 }
 
 /// Describes the type of package archive. This can be derived from the file extension of a package.

--- a/crates/rattler_package_streaming/src/lib.rs
+++ b/crates/rattler_package_streaming/src/lib.rs
@@ -1,0 +1,42 @@
+//! This crate provides the ability to extract a package archive or specific parts of it.
+
+use std::path::Path;
+
+#[cfg(feature = "sync")]
+pub mod read;
+
+/// An error that can occur when extracting a package archive.
+#[derive(thiserror::Error, Debug)]
+pub enum ExtractError {
+    #[error("an io error occurred")]
+    IoError(#[from] std::io::Error),
+
+    #[error("could not create the destination path")]
+    CouldNotCreateDestination(#[source] std::io::Error),
+
+    #[error("invalid zip archive")]
+    ZipError(#[from] zip::result::ZipError),
+}
+
+/// Describes the type of package archive. This can be derived from the file extension of a package.
+#[derive(Copy, Clone, Debug, Ord, PartialOrd, Eq, PartialEq, Hash)]
+pub enum ArchiveType {
+    /// A file with the `.tar.bz2` extension.
+    TarBz2,
+
+    /// A file with the `.conda` extension.
+    Conda,
+}
+
+impl ArchiveType {
+    /// Tries to determine the type of a Conda archive from its filename.
+    pub fn try_from(path: &Path) -> Option<ArchiveType> {
+        if path.ends_with(".conda") {
+            Some(ArchiveType::Conda)
+        } else if path.ends_with(".tar.bz2") {
+            Some(ArchiveType::TarBz2)
+        } else {
+            None
+        }
+    }
+}

--- a/crates/rattler_package_streaming/src/lib.rs
+++ b/crates/rattler_package_streaming/src/lib.rs
@@ -31,9 +31,10 @@ pub enum ArchiveType {
 impl ArchiveType {
     /// Tries to determine the type of a Conda archive from its filename.
     pub fn try_from(path: &Path) -> Option<ArchiveType> {
-        if path.ends_with(".conda") {
+        let file_name = path.file_name()?.to_string_lossy();
+        if file_name.ends_with(".conda") {
             Some(ArchiveType::Conda)
-        } else if path.ends_with(".tar.bz2") {
+        } else if file_name.ends_with(".tar.bz2") {
             Some(ArchiveType::TarBz2)
         } else {
             None

--- a/crates/rattler_package_streaming/src/lib.rs
+++ b/crates/rattler_package_streaming/src/lib.rs
@@ -2,10 +2,7 @@
 
 use std::path::Path;
 
-#[cfg(feature = "sync")]
 pub mod read;
-
-#[cfg(feature = "sync")]
 pub mod seek;
 
 /// An error that can occur when extracting a package archive.

--- a/crates/rattler_package_streaming/src/read.rs
+++ b/crates/rattler_package_streaming/src/read.rs
@@ -6,7 +6,7 @@ use zip::read::read_zipfile_from_stream;
 /// Returns the `.tar.bz2` as a decompressed `tar::Archive`. The `tar::Archive` can be used to
 /// extract the files from it, or perform introspection.
 pub fn stream_tar_bz2(reader: impl Read) -> tar::Archive<impl Read + Sized> {
-    tar::Archive::new(bzip2_rs::DecoderReader::new(reader))
+    tar::Archive::new(bzip2::read::BzDecoder::new(reader))
 }
 
 /// Returns the `.tar.zst` as a decompressed `tar` archive. The `tar::Archive` can be used to
@@ -17,47 +17,10 @@ pub(crate) fn stream_tar_zst(
     Ok(tar::Archive::new(zstd::stream::read::Decoder::new(reader)?))
 }
 
-/// Returns the `.tar.bz2` as a decompressed `tar` archive where the data is decoded in parallel.
-///
-/// `max_preread_len` defines how many bytes can be pre-read from the block. This significantly
-/// speeds up the reading process, which would otherwise limit the decoder to using at most two
-/// threads, independently of how many more are available. Setting a value close to zero is then
-/// highly discouraged, at the same time using a value higher than the amount of available memory
-/// could lead to OOM for files with a high compression ratio
-#[cfg(feature = "rayon")]
-pub fn parallel_stream_tar_bz2(
-    reader: impl Read,
-    max_preread_len: usize,
-) -> tar::Archive<impl Read + Sized> {
-    tar::Archive::new(bzip2_rs::ParallelDecoderReader::new(
-        reader,
-        bzip2_rs::RayonThreadPool,
-        max_preread_len,
-    ))
-}
-
 /// Extracts the contents a `.tar.bz2` package archive.
 pub fn extract_tar_bz2(reader: impl Read, destination: &Path) -> Result<(), ExtractError> {
     std::fs::create_dir_all(destination).map_err(ExtractError::CouldNotCreateDestination)?;
     stream_tar_bz2(reader).unpack(destination)?;
-    Ok(())
-}
-
-/// Extracts the contents of a `.tar.bz2` package archive while decoding the archive in parallel.
-///
-/// `max_preread_len` defines how many bytes can be pre-read from the block. This significantly
-/// speeds up the reading process, which would otherwise limit the decoder to using at most two
-/// threads, independently of how many more are available. Setting a value close to zero is then
-/// highly discouraged, at the same time using a value higher than the amount of available memory
-/// could lead to OOM for files with a high compression ratio
-#[cfg(feature = "rayon")]
-pub fn parallel_extract_tar_bz2(
-    reader: impl Read,
-    destination: &Path,
-    max_preread_len: usize,
-) -> Result<(), ExtractError> {
-    std::fs::create_dir_all(destination).map_err(ExtractError::CouldNotCreateDestination)?;
-    parallel_stream_tar_bz2(reader, max_preread_len).unpack(destination)?;
     Ok(())
 }
 

--- a/crates/rattler_package_streaming/src/read.rs
+++ b/crates/rattler_package_streaming/src/read.rs
@@ -1,4 +1,5 @@
 use super::ExtractError;
+use std::ffi::OsStr;
 use std::{io::Read, path::Path};
 use zip::read::read_zipfile_from_stream;
 
@@ -67,7 +68,12 @@ pub fn extract_conda(mut reader: impl Read, destination: &Path) -> Result<(), Ex
 
     // Iterate over all entries in the zip-file and extract them one-by-one
     while let Some(file) = read_zipfile_from_stream(&mut reader)? {
-        if file.mangled_name().ends_with(".tar.zst") {
+        if file
+            .mangled_name()
+            .file_name()
+            .map(OsStr::to_string_lossy)
+            .map_or(false, |file_name| file_name.ends_with(".tar.zst"))
+        {
             stream_tar_zst(file)?.unpack(destination)?;
         }
     }

--- a/crates/rattler_package_streaming/src/read.rs
+++ b/crates/rattler_package_streaming/src/read.rs
@@ -1,0 +1,76 @@
+use super::ExtractError;
+use std::{io::Read, path::Path};
+use zip::read::read_zipfile_from_stream;
+
+/// Returns the `.tar.bz2` as a decompressed `tar::Archive`. The `tar::Archive` can be used to
+/// extract the files from it, or perform introspection.
+pub fn stream_tar_bz2(reader: impl Read) -> tar::Archive<impl Read + Sized> {
+    tar::Archive::new(bzip2_rs::DecoderReader::new(reader))
+}
+
+/// Returns the `.tar.zst` as a decompressed `tar` archive. The `tar::Archive` can be used to
+/// extract the files from it, or perform introspection.
+pub(crate) fn stream_tar_zst(
+    reader: impl Read,
+) -> Result<tar::Archive<impl Read + Sized>, ExtractError> {
+    Ok(tar::Archive::new(zstd::stream::read::Decoder::new(reader)?))
+}
+
+/// Returns the `.tar.bz2` as a decompressed `tar` archive where the data is decoded in parallel.
+///
+/// `max_preread_len` defines how many bytes can be pre-read from the block. This significantly
+/// speeds up the reading process, which would otherwise limit the decoder to using at most two
+/// threads, independently of how many more are available. Setting a value close to zero is then
+/// highly discouraged, at the same time using a value higher than the amount of available memory
+/// could lead to OOM for files with a high compression ratio
+#[cfg(feature = "rayon")]
+pub fn parallel_stream_tar_bz2(
+    reader: impl Read,
+    max_preread_len: usize,
+) -> tar::Archive<impl Read + Sized> {
+    tar::Archive::new(bzip2_rs::ParallelDecoderReader::new(
+        reader,
+        bzip2_rs::RayonThreadPool,
+        max_preread_len,
+    ))
+}
+
+/// Extracts the contents a `.tar.bz2` package archive.
+pub fn extract_tar_bz2(reader: impl Read, destination: &Path) -> Result<(), ExtractError> {
+    std::fs::create_dir_all(destination).map_err(ExtractError::CouldNotCreateDestination)?;
+    stream_tar_bz2(reader).unpack(destination)?;
+    Ok(())
+}
+
+/// Extracts the contents of a `.tar.bz2` package archive while decoding the archive in parallel.
+///
+/// `max_preread_len` defines how many bytes can be pre-read from the block. This significantly
+/// speeds up the reading process, which would otherwise limit the decoder to using at most two
+/// threads, independently of how many more are available. Setting a value close to zero is then
+/// highly discouraged, at the same time using a value higher than the amount of available memory
+/// could lead to OOM for files with a high compression ratio
+#[cfg(feature = "rayon")]
+pub fn parallel_extract_tar_bz2(
+    reader: impl Read,
+    destination: &Path,
+    max_preread_len: usize,
+) -> Result<(), ExtractError> {
+    std::fs::create_dir_all(destination).map_err(ExtractError::CouldNotCreateDestination)?;
+    parallel_stream_tar_bz2(reader, max_preread_len).unpack(destination)?;
+    Ok(())
+}
+
+/// Extracts the contents of a `.conda` package archive.
+pub fn extract_conda(mut reader: impl Read, destination: &Path) -> Result<(), ExtractError> {
+    // Construct the destination path if it doesnt exist yet
+    std::fs::create_dir_all(destination).map_err(ExtractError::CouldNotCreateDestination)?;
+
+    // Iterate over all entries in the zip-file and extract them one-by-one
+    while let Some(file) = read_zipfile_from_stream(&mut reader)? {
+        if file.mangled_name().ends_with(".tar.zst") {
+            stream_tar_zst(file)?.unpack(destination)?;
+        }
+    }
+
+    Ok(())
+}

--- a/crates/rattler_package_streaming/src/seek.rs
+++ b/crates/rattler_package_streaming/src/seek.rs
@@ -1,0 +1,60 @@
+use crate::read::stream_tar_zst;
+use crate::ExtractError;
+use std::io::{Read, Seek, SeekFrom};
+use zip::CompressionMethod;
+
+fn stream_conda_zip_entry<'a>(
+    mut archive: zip::ZipArchive<impl Read + Seek + 'a>,
+    file_name: &str,
+) -> Result<tar::Archive<impl Read + Sized + 'a>, ExtractError> {
+    // Find the offset and size of the file in the zip.
+    let (offset, size) = {
+        let entry = archive.by_name(file_name)?;
+
+        // Make sure the file is uncompressed.
+        if entry.compression() != CompressionMethod::Stored {
+            return Err(ExtractError::UnsupportedCompressionMethod);
+        }
+
+        (entry.data_start(), entry.size())
+    };
+
+    // Seek to the position of the file
+    let mut reader = archive.into_inner();
+    reader.seek(SeekFrom::Start(offset))?;
+
+    // Open the info entry for reading
+    stream_tar_zst(reader.take(size))
+}
+
+/// Stream the info section of a `.conda` package as a tar archive.
+pub fn stream_conda_info<'a>(
+    reader: impl Read + Seek + 'a,
+) -> Result<tar::Archive<impl Read + Sized + 'a>, ExtractError> {
+    let archive = zip::ZipArchive::new(reader)?;
+
+    // Find the info entry in the archive
+    let file_name = archive
+        .file_names()
+        .find(|file_name| file_name.starts_with("info-") && file_name.ends_with(".tar.zst"))
+        .ok_or(ExtractError::MissingComponent)?
+        .to_owned();
+
+    stream_conda_zip_entry(archive, &file_name)
+}
+
+/// Stream the content section of a `.conda` package as a tar archive.
+pub fn stream_conda_content<'a>(
+    reader: impl Read + Seek + 'a,
+) -> Result<tar::Archive<impl Read + Sized + 'a>, ExtractError> {
+    let archive = zip::ZipArchive::new(reader)?;
+
+    // Find the content entry in the archive
+    let file_name = archive
+        .file_names()
+        .find(|file_name| file_name.starts_with("pkg-") && file_name.ends_with(".tar.zst"))
+        .ok_or(ExtractError::MissingComponent)?
+        .to_owned();
+
+    stream_conda_zip_entry(archive, &file_name)
+}

--- a/crates/rattler_package_streaming/tests/extract.rs
+++ b/crates/rattler_package_streaming/tests/extract.rs
@@ -1,0 +1,66 @@
+use rattler_package_streaming::{
+    read::{extract_conda, extract_tar_bz2, parallel_extract_tar_bz2},
+    ArchiveType,
+};
+use std::fs::File;
+use std::path::{Path, PathBuf};
+
+fn find_all_archives() -> impl Iterator<Item = PathBuf> {
+    std::fs::read_dir(Path::new(env!("CARGO_MANIFEST_DIR")).join("data"))
+        .unwrap()
+        .filter_map(Result::ok)
+        .map(|d| d.path())
+}
+
+#[test]
+fn text_extract_conda() {
+    let temp_dir = Path::new(env!("CARGO_TARGET_TMPDIR"));
+    println!("Target dir: {}", temp_dir.display());
+
+    for file_path in
+        find_all_archives().filter(|path| ArchiveType::try_from(path) == Some(ArchiveType::Conda))
+    {
+        println!("Name: {}", file_path.display());
+
+        let target_dir = temp_dir.join(file_path.file_stem().unwrap());
+        extract_conda(File::open(&file_path).unwrap(), &target_dir).unwrap();
+    }
+}
+
+#[test]
+fn text_extract_tar_bz2() {
+    let temp_dir = Path::new(env!("CARGO_TARGET_TMPDIR"));
+    println!("Target dir: {}", temp_dir.display());
+
+    for file_path in
+        find_all_archives().filter(|path| ArchiveType::try_from(path) == Some(ArchiveType::TarBz2))
+    {
+        println!("Name: {}", file_path.display());
+
+        let target_dir = temp_dir.join(file_path.file_stem().unwrap());
+        extract_tar_bz2(File::open(&file_path).unwrap(), &target_dir).unwrap();
+    }
+}
+
+#[test]
+fn text_extract_tar_parallel() {
+    let temp_dir = Path::new(env!("CARGO_TARGET_TMPDIR"));
+    println!("Target dir: {}", temp_dir.display());
+
+    for file_path in
+        find_all_archives().filter(|path| ArchiveType::try_from(path) == Some(ArchiveType::TarBz2))
+    {
+        println!("Name: {}", file_path.display());
+
+        let target_dir = temp_dir.join(format!(
+            "{}-parallel",
+            file_path.file_stem().unwrap().to_string_lossy().as_ref()
+        ));
+        parallel_extract_tar_bz2(
+            File::open(&file_path).unwrap(),
+            &target_dir,
+            1024 * 1024 * 10,
+        )
+        .unwrap();
+    }
+}

--- a/crates/rattler_package_streaming/tests/extract.rs
+++ b/crates/rattler_package_streaming/tests/extract.rs
@@ -1,5 +1,5 @@
 use rattler_package_streaming::{
-    read::{extract_conda, extract_tar_bz2, parallel_extract_tar_bz2},
+    read::{extract_conda, extract_tar_bz2},
     ArchiveType,
 };
 use std::fs::File;
@@ -62,28 +62,5 @@ fn test_extract_tar_bz2() {
 
         let target_dir = temp_dir.join(file_path.file_stem().unwrap());
         extract_tar_bz2(File::open(&file_path).unwrap(), &target_dir).unwrap();
-    }
-}
-
-#[test]
-fn test_extract_tar_parallel() {
-    let temp_dir = Path::new(env!("CARGO_TARGET_TMPDIR"));
-    println!("Target dir: {}", temp_dir.display());
-
-    for file_path in
-        find_all_archives().filter(|path| ArchiveType::try_from(path) == Some(ArchiveType::TarBz2))
-    {
-        println!("Name: {}", file_path.display());
-
-        let target_dir = temp_dir.join(format!(
-            "{}-parallel",
-            file_path.file_stem().unwrap().to_string_lossy().as_ref()
-        ));
-        parallel_extract_tar_bz2(
-            File::open(&file_path).unwrap(),
-            &target_dir,
-            1024 * 1024 * 10,
-        )
-        .unwrap();
     }
 }

--- a/crates/rattler_package_streaming/tests/extract.rs
+++ b/crates/rattler_package_streaming/tests/extract.rs
@@ -13,7 +13,7 @@ fn find_all_archives() -> impl Iterator<Item = PathBuf> {
 }
 
 #[test]
-fn text_extract_conda() {
+fn test_extract_conda() {
     let temp_dir = Path::new(env!("CARGO_TARGET_TMPDIR"));
     println!("Target dir: {}", temp_dir.display());
 
@@ -28,7 +28,30 @@ fn text_extract_conda() {
 }
 
 #[test]
-fn text_extract_tar_bz2() {
+fn test_stream_info() {
+    let temp_dir = Path::new(env!("CARGO_TARGET_TMPDIR"));
+    println!("Target dir: {}", temp_dir.display());
+
+    for file_path in
+        find_all_archives().filter(|path| ArchiveType::try_from(path) == Some(ArchiveType::Conda))
+    {
+        println!("Name: {}", file_path.display());
+
+        let mut info_stream =
+            rattler_package_streaming::seek::stream_conda_info(File::open(&file_path).unwrap())
+                .unwrap();
+
+        let target_dir = temp_dir.join(format!(
+            "{}-info",
+            file_path.file_stem().unwrap().to_string_lossy().as_ref()
+        ));
+
+        info_stream.unpack(target_dir).unwrap();
+    }
+}
+
+#[test]
+fn test_extract_tar_bz2() {
     let temp_dir = Path::new(env!("CARGO_TARGET_TMPDIR"));
     println!("Target dir: {}", temp_dir.display());
 
@@ -43,7 +66,7 @@ fn text_extract_tar_bz2() {
 }
 
 #[test]
-fn text_extract_tar_parallel() {
+fn test_extract_tar_parallel() {
     let temp_dir = Path::new(env!("CARGO_TARGET_TMPDIR"));
     println!("Target dir: {}", temp_dir.display());
 


### PR DESCRIPTION
First part of rust package streaming. This is still missing tests. This initial PR only provides a sync `Read` implementation. Later additions could provide more functionality with `Seek` support and an async implementation needed for `micromamba`.

The `.tar.bz2` extract process uses parallel decoded `bzip2` which is extremely fast.