### PR TITLE
feat: async extraction methods

### DIFF
--- a/crates/rattler_package_streaming/Cargo.toml
+++ b/crates/rattler_package_streaming/Cargo.toml
@@ -16,7 +16,13 @@ bzip2 = { version = "0.4" }
 zip = { version = "0.6.3" }
 zstd = "0.12.1"
 reqwest = { version = "0.11.13", optional = true }
+tokio = { version = "1", optional = true }
+tokio-util = { version = "0.7", optional = true }
+futures-util = { version = "0.3.25", optional = true }
 
 [features]
-tokio = ["bzip2/tokio"]
+tokio = ["dep:tokio", "bzip2/tokio", "tokio/fs", "tokio-util/io", "tokio-util/io-util", "reqwest?/stream"]
 reqwest = ["reqwest/blocking"]
+
+[dev-dependencies]
+tokio = { version = "1", features=["rt", "macros"]}

--- a/crates/rattler_package_streaming/src/lib.rs
+++ b/crates/rattler_package_streaming/src/lib.rs
@@ -8,6 +8,9 @@ pub mod seek;
 #[cfg(feature = "reqwest")]
 pub mod reqwest;
 
+#[cfg(feature = "tokio")]
+pub mod tokio;
+
 /// An error that can occur when extracting a package archive.
 #[derive(thiserror::Error, Debug)]
 pub enum ExtractError {
@@ -32,6 +35,9 @@ pub enum ExtractError {
 
     #[error("unsupported package archive format")]
     UnsupportedArchiveType,
+
+    #[error("the task was cancelled")]
+    Cancelled,
 }
 
 /// Describes the type of package archive. This can be derived from the file extension of a package.

--- a/crates/rattler_package_streaming/src/reqwest/tokio.rs
+++ b/crates/rattler_package_streaming/src/reqwest/tokio.rs
@@ -1,24 +1,27 @@
-#[cfg(feature = "tokio")]
-pub mod tokio;
-
 use crate::{ArchiveType, ExtractError};
-use reqwest::blocking::{Client, Response};
+use futures_util::stream::TryStreamExt;
 use reqwest::IntoUrl;
+use reqwest::{Client, Response};
 use std::path::Path;
+use tokio_util::io::StreamReader;
 
 /// Extracts the contents a `.tar.bz2` package archive from the specified remote location.
 ///
 /// ```rust,no_run
+/// # #[tokio::main]
+/// # async fn main() {
 /// # use std::path::Path;
-/// use rattler_package_streaming::reqwest::extract_tar_bz2;
-/// # use reqwest::blocking::Client;
+/// use rattler_package_streaming::reqwest::tokio::extract_tar_bz2;
+/// # use reqwest::Client;
 /// let _ = extract_tar_bz2(
 ///     Client::default(),
 ///     "https://conda.anaconda.org/conda-forge/win-64/python-3.11.0-hcf16a7b_0_cpython.tar.bz2",
 ///     Path::new("/tmp"))
+///     .await
 ///     .unwrap();
+/// # }
 /// ```
-pub fn extract_tar_bz2(
+pub async fn extract_tar_bz2(
     client: Client,
     url: impl IntoUrl,
     destination: &Path,
@@ -27,26 +30,38 @@ pub fn extract_tar_bz2(
     let response = client
         .get(url)
         .send()
+        .await
         .and_then(Response::error_for_status)
         .map_err(ExtractError::ReqwestError)?;
 
+    // Get the response as a stream
+    let reader = StreamReader::new(
+        response
+            .bytes_stream()
+            .map_err(|err| std::io::Error::new(std::io::ErrorKind::Other, err)),
+    );
+
     // The `response` is used to stream in the package data
-    crate::read::extract_tar_bz2(response, destination)
+    crate::tokio::async_read::extract_tar_bz2(reader, destination).await
 }
 
 /// Extracts the contents a `.conda` package archive from the specified remote location.
 ///
 /// ```rust,no_run
+/// # #[tokio::main]
+/// # async fn main() {
 /// # use std::path::Path;
-/// use rattler_package_streaming::reqwest::extract_conda;
-/// # use reqwest::blocking::Client;
+/// use rattler_package_streaming::reqwest::tokio::extract_conda;
+/// # use reqwest::Client;
 /// let _ = extract_conda(
 ///     Client::default(),
 ///     "https://conda.anaconda.org/conda-forge/linux-64/python-3.10.8-h4a9ceb5_0_cpython.conda",
 ///     Path::new("/tmp"))
+///     .await
 ///     .unwrap();
+/// # }
 /// ```
-pub fn extract_conda(
+pub async fn extract_conda(
     client: Client,
     url: impl IntoUrl,
     destination: &Path,
@@ -55,27 +70,43 @@ pub fn extract_conda(
     let response = client
         .get(url)
         .send()
+        .await
         .and_then(Response::error_for_status)
         .map_err(ExtractError::ReqwestError)?;
 
+    // Get the response as a stream
+    let reader = StreamReader::new(
+        response
+            .bytes_stream()
+            .map_err(|err| std::io::Error::new(std::io::ErrorKind::Other, err)),
+    );
+
     // The `response` is used to stream in the package data
-    crate::read::extract_conda(response, destination)
+    crate::tokio::async_read::extract_conda(reader, destination).await
 }
 
 /// Extracts the contents a package archive from the specified remote location. The type of package
 /// is determined based on the path of the url.
 ///
 /// ```rust,no_run
+/// # #[tokio::main]
+/// # async fn main() {
 /// # use std::path::Path;
-/// use rattler_package_streaming::reqwest::extract;
-/// # use reqwest::blocking::Client;
+/// use rattler_package_streaming::reqwest::tokio::extract;
+/// # use reqwest::Client;
 /// let _ = extract(
 ///     Client::default(),
 ///     "https://conda.anaconda.org/conda-forge/linux-64/python-3.10.8-h4a9ceb5_0_cpython.conda",
 ///     Path::new("/tmp"))
+///     .await
 ///     .unwrap();
+/// # }
 /// ```
-pub fn extract(client: Client, url: impl IntoUrl, destination: &Path) -> Result<(), ExtractError> {
+pub async fn extract(
+    client: Client,
+    url: impl IntoUrl,
+    destination: &Path,
+) -> Result<(), ExtractError> {
     let url = url
         .into_url()
         .map_err(reqwest::Error::from)
@@ -84,7 +115,7 @@ pub fn extract(client: Client, url: impl IntoUrl, destination: &Path) -> Result<
     match ArchiveType::try_from(Path::new(url.path()))
         .ok_or(ExtractError::UnsupportedArchiveType)?
     {
-        ArchiveType::TarBz2 => extract_tar_bz2(client, url, destination),
-        ArchiveType::Conda => extract_conda(client, url, destination),
+        ArchiveType::TarBz2 => extract_tar_bz2(client, url, destination).await,
+        ArchiveType::Conda => extract_conda(client, url, destination).await,
     }
 }

--- a/crates/rattler_package_streaming/src/tokio/async_read.rs
+++ b/crates/rattler_package_streaming/src/tokio/async_read.rs
@@ -1,0 +1,50 @@
+use crate::ExtractError;
+use std::path::Path;
+use tokio::io::AsyncRead;
+use tokio_util::io::SyncIoBridge;
+
+/// Extracts the contents a `.tar.bz2` package archive.
+pub async fn extract_tar_bz2(
+    reader: impl AsyncRead + Send + 'static,
+    destination: &Path,
+) -> Result<(), ExtractError> {
+    // Create a async -> sync bridge
+    let reader = SyncIoBridge::new(Box::pin(reader));
+
+    // Spawn a block task to perform the extraction
+    let destination = destination.to_owned();
+    match tokio::task::spawn_blocking(move || crate::read::extract_tar_bz2(reader, &destination))
+        .await
+    {
+        Ok(result) => result,
+        Err(err) => {
+            if let Ok(reason) = err.try_into_panic() {
+                std::panic::resume_unwind(reason);
+            }
+            Err(ExtractError::Cancelled)
+        }
+    }
+}
+
+/// Extracts the contents of a `.conda` package archive.
+pub async fn extract_conda(
+    reader: impl AsyncRead + Send + 'static,
+    destination: &Path,
+) -> Result<(), ExtractError> {
+    // Create a async -> sync bridge
+    let reader = SyncIoBridge::new(Box::pin(reader));
+
+    // Spawn a block task to perform the extraction
+    let destination = destination.to_owned();
+    match tokio::task::spawn_blocking(move || crate::read::extract_conda(reader, &destination))
+        .await
+    {
+        Ok(result) => result,
+        Err(err) => {
+            if let Ok(reason) = err.try_into_panic() {
+                std::panic::resume_unwind(reason);
+            }
+            Err(ExtractError::Cancelled)
+        }
+    }
+}

--- a/crates/rattler_package_streaming/src/tokio/mod.rs
+++ b/crates/rattler_package_streaming/src/tokio/mod.rs
@@ -1,0 +1,1 @@
+pub mod async_read;

--- a/crates/rattler_package_streaming/tests/extract.rs
+++ b/crates/rattler_package_streaming/tests/extract.rs
@@ -65,6 +65,48 @@ fn test_extract_tar_bz2() {
     }
 }
 
+#[cfg(feature = "tokio")]
+#[tokio::test]
+async fn test_extract_tar_bz2_async() {
+    let temp_dir = Path::new(env!("CARGO_TARGET_TMPDIR")).join("tokio");
+    println!("Target dir: {}", temp_dir.display());
+
+    for file_path in
+        find_all_archives().filter(|path| ArchiveType::try_from(path) == Some(ArchiveType::TarBz2))
+    {
+        println!("Name: {}", file_path.display());
+
+        let target_dir = temp_dir.join(file_path.file_stem().unwrap());
+        rattler_package_streaming::tokio::async_read::extract_tar_bz2(
+            tokio::fs::File::open(&file_path).await.unwrap(),
+            &target_dir,
+        )
+        .await
+        .unwrap();
+    }
+}
+
+#[cfg(feature = "tokio")]
+#[tokio::test]
+async fn test_extract_conda_async() {
+    let temp_dir = Path::new(env!("CARGO_TARGET_TMPDIR")).join("tokio");
+    println!("Target dir: {}", temp_dir.display());
+
+    for file_path in
+        find_all_archives().filter(|path| ArchiveType::try_from(path) == Some(ArchiveType::Conda))
+    {
+        println!("Name: {}", file_path.display());
+
+        let target_dir = temp_dir.join(file_path.file_stem().unwrap());
+        rattler_package_streaming::tokio::async_read::extract_conda(
+            tokio::fs::File::open(&file_path).await.unwrap(),
+            &target_dir,
+        )
+        .await
+        .unwrap();
+    }
+}
+
 #[cfg(feature = "reqwest")]
 #[test]
 fn test_extract_url() {
@@ -81,5 +123,26 @@ fn test_extract_url() {
 
         let target_dir = temp_dir.join(name);
         rattler_package_streaming::reqwest::extract(Default::default(), url, &target_dir).unwrap();
+    }
+}
+
+#[cfg(all(feature = "reqwest", feature = "tokio"))]
+#[tokio::test]
+async fn test_extract_url_async() {
+    let temp_dir = Path::new(env!("CARGO_TARGET_TMPDIR")).join("tokio");
+    println!("Target dir: {}", temp_dir.display());
+
+    for url in [
+        "https://conda.anaconda.org/conda-forge/win-64/ruff-0.0.205-py39h5b3f8fb_0.conda",
+        "https://conda.anaconda.org/conda-forge/win-64/python-3.11.0-hcf16a7b_0_cpython.tar.bz2",
+    ] {
+        let (_, filename) = url.rsplit_once('/').unwrap();
+        let name = Path::new(filename);
+        println!("Name: {}", name.display());
+
+        let target_dir = temp_dir.join(name);
+        rattler_package_streaming::reqwest::tokio::extract(Default::default(), url, &target_dir)
+            .await
+            .unwrap();
     }
 }


### PR DESCRIPTION
Async methods to extract conda packages. 

Until we find a better library to do async tar and zip archive handling this code wraps the sync code in an async context with [`SyncIoBridge`](https://docs.rs/tokio-util/latest/tokio_util/io/struct.SyncIoBridge.html).

I briefly benchmarked the code which resulted in:

|                 | sync       | async      |       |
|-----------------|------------|------------|-------|
| extract_conda   | **5.725s** | 5.965s     | +4.1% |
| extract_tar_bz2 | **2.424s** | 2.515s     | +3.7% |
| extract_url     | 9.694s     | **9.359s** | -3.5% |

All in all, I think these results are good enough to merge the async functions.