### PR TITLE
feat: use nvml instead of libcuda to detect available cuda version

### DIFF
--- a/.github/workflows/rust-compile.yml
+++ b/.github/workflows/rust-compile.yml
@@ -36,9 +36,6 @@ jobs:
       fail-fast: false
       matrix:
         os: ["ubuntu-latest", "windows-latest", "macOS-latest"]
-        include:
-          - os: "windows-latest"
-            RUSTFLAGS: "$RUSTFLAGS -Ctarget-feature=+crt-static"
     steps:
       - uses: actions/checkout@v3
         with:
@@ -51,7 +48,7 @@ jobs:
       - uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --all-features
+          args: --all-features -- --nocapture
 
   fmt:
     name: Rustfmt

--- a/crates/rattler_virtual_packages/src/cuda.rs
+++ b/crates/rattler_virtual_packages/src/cuda.rs
@@ -11,12 +11,117 @@ use std::{
 pub fn cuda_version() -> Option<Version> {
     static DETECTED_CUDA_VERSION: OnceCell<Option<Version>> = OnceCell::new();
     DETECTED_CUDA_VERSION
-        .get_or_init(detect_cuda_version)
+        .get_or_init(detect_cuda_version_via_nvml)
         .clone()
 }
 
-/// Attempts to detect the version of CUDA present in the current operating system.
-pub fn detect_cuda_version() -> Option<Version> {
+/// Attempts to detect the version of CUDA present in the current operating system by loading the
+/// NVIDIA Management Library and querying the CUDA driver version. The method is preferred over
+/// [`detect_cuda_version_via_libcuda`] because that method might fail base on environment
+/// variables.
+///
+/// Although the required methods in the runtime are not implemented on much older machines it is
+/// considered old enough to be usable for our use case. Since Conda doesnt provide old versions of
+/// the CUDA SDK anyway this is considered a non-issue.
+pub fn detect_cuda_version_via_nvml() -> Option<Version> {
+    // Try to open the library
+    let library = nvml_library_paths()
+        .iter()
+        .find_map(|path| unsafe { libloading::Library::new(*path).ok() })?;
+
+    // Get the initialization function. We first try to get `nvmlInit_v2` but if we can't find that
+    // we use the `nvmlInit` function.
+    let nvml_init: Symbol<unsafe extern "C" fn() -> c_int> = unsafe {
+        library
+            .get(b"nvmlInit_v2\0")
+            .or_else(|_| library.get(b"nvmlInit\0"))
+    }
+    .ok()?;
+
+    // Find the shutdown function
+    let nvml_shutdown: Symbol<unsafe extern "C" fn() -> c_int> =
+        unsafe { library.get(b"nvmlShutdown\0") }.ok()?;
+
+    // Find the `nvmlSystemGetCudaDriverVersion_v2` function. If that function cannot be found, fall
+    // back to the `nvmlSystemGetCudaDriverVersion` function instead.
+    let nvml_system_get_cuda_driver_version: Symbol<unsafe extern "C" fn(*mut c_int) -> c_int> =
+        unsafe {
+            library
+                .get(b"nvmlSystemGetCudaDriverVersion_v2\0")
+                .or_else(|_| library.get(b"nvmlSystemGetCudaDriverVersion\0"))
+        }
+        .ok()?;
+
+    // Call the initialization function
+    if unsafe { nvml_init() } != 0 {
+        return None;
+    }
+
+    // Get the version
+    let mut cuda_driver_version = MaybeUninit::uninit();
+    let result = unsafe { nvml_system_get_cuda_driver_version(cuda_driver_version.as_mut_ptr()) };
+
+    // Call the shutdown function (don't care about the result of the function). Whatever happens,
+    // after calling `nvmlInit` we have to call `nvmlShutdown`.
+    let _ = unsafe { nvml_shutdown() };
+
+    // If the call failed we dont have a version
+    if result != 0 {
+        return None;
+    }
+
+    // We can assume the value is initialized by the `nvmlSystemGetCudaDriverVersion` function.
+    let version = unsafe { cuda_driver_version.assume_init() };
+
+    // Convert the version integer to a version string
+    Version::from_str(&format!("{}.{}", version / 1000, (version % 1000) / 10)).ok()
+}
+
+/// Returns platform specific set of search paths for the CUDA library.
+///
+/// On Windows and Linux, the nvml library is installed by the NVIDIA driver package, and is
+/// typically found in the standard library path, rather than with the CUDA SDK (which is optional
+/// for running CUDA apps).
+///
+/// On macOS, the CUDA library is only installed with the CUDA SDK, and might not be in the library
+/// path.
+fn nvml_library_paths() -> &'static [&'static str] {
+    #[cfg(target_os = "macos")]
+    static FILENAMES: &[&str] = &[
+        "libnvidia-ml.1.dylib", // Check library path first
+        "libnvidia-ml.dylib",
+        "/usr/local/cuda/lib/libnvidia-ml.1.dylib",
+        "/usr/local/cuda/lib/libnvidia-ml.dylib",
+    ];
+    #[cfg(target_os = "linux")]
+    static FILENAMES: &[&str] = &[
+        "libnvidia-ml.so.1", // Check library path first
+        "libnvidia-ml.so",
+        "/usr/lib64/nvidia/libnvidia-ml.so.1", // RHEL/Centos/Fedora
+        "/usr/lib64/nvidia/libnvidia-ml.so",
+        "/usr/lib/x86_64-linux-gnu/libnvidia-ml.so.1", // Ubuntu
+        "/usr/lib/x86_64-linux-gnu/libnvidia-ml.so",
+        "/usr/lib/wsl/lib/libnvidia-ml.so.1", // WSL
+        "/usr/lib/wsl/lib/libnvidia-ml.so",
+    ];
+    #[cfg(windows)]
+    static FILENAMES: &[&str] = &["nvml.dll"];
+    #[cfg(not(any(target_os = "linux", target_os = "macos", windows)))]
+    compile_error!("unsupported target os");
+    FILENAMES
+}
+
+/// Attempts to detect the version of CUDA present in the current operating system by loading the
+/// cuda runtime library and querying the CUDA driver version.
+///
+/// The behavior of functions from `libcuda` depend on the environment variable
+/// `CUDA_VISIBLE_DEVICES`. If users have this variable set in their environment this function will
+/// likely not return the correct value.
+///
+/// Therefore you should use the function [`detect_cuda_version_via_nvml`] instead which does not
+/// have this limitation.
+#[allow(dead_code)]
+pub fn detect_cuda_version_via_libcuda() -> Option<Version> {
     // Try to open the library
     let cuda_library = cuda_library_paths()
         .iter()
@@ -55,15 +160,21 @@ pub fn detect_cuda_version() -> Option<Version> {
 fn cuda_library_paths() -> &'static [&'static str] {
     #[cfg(target_os = "macos")]
     static FILENAMES: &[&str] = &[
-        "libcuda.dylib", // Check library path first
+        "libcuda.1.dylib", // Check library path first
+        "libcuda.dylib",
+        "/usr/local/cuda/lib/libcuda.1.dylib",
         "/usr/local/cuda/lib/libcuda.dylib",
     ];
     #[cfg(target_os = "linux")]
     static FILENAMES: &[&str] = &[
-        "libcuda.so",                           // Check library path first
-        "/usr/lib64/nvidia/libcuda.so",         // RHEL/Centos/Fedora
-        "/usr/lib/x86_64-linux-gnu/libcuda.so", // Ubuntu
-        "/usr/lib/wsl/lib/libcuda.so",          // WSL (workaround)
+        "libcuda.so.1", // Check library path first
+        "libcuda.so",
+        "/usr/lib64/nvidia/libcuda.so.1", // RHEL/Centos/Fedora
+        "/usr/lib64/nvidia/libcuda.so",
+        "/usr/lib/x86_64-linux-gnu/libcuda.so.1", // Ubuntu
+        "/usr/lib/x86_64-linux-gnu/libcuda.so",
+        "/usr/lib/wsl/lib/libcuda.so.1", // WSL
+        "/usr/lib/wsl/lib/libcuda.so",
     ];
     #[cfg(windows)]
     static FILENAMES: &[&str] = &["nvcuda.dll"];
@@ -74,11 +185,11 @@ fn cuda_library_paths() -> &'static [&'static str] {
 
 #[cfg(test)]
 mod test {
-    use super::detect_cuda_version;
+    use super::detect_cuda_version_via_nvml;
 
     #[test]
     pub fn doesnt_crash() {
-        let version = detect_cuda_version();
+        let version = detect_cuda_version_via_nvml();
         println!("Cuda {:?}", version);
     }
 }

--- a/crates/rattler_virtual_packages/src/lib.rs
+++ b/crates/rattler_virtual_packages/src/lib.rs
@@ -1,17 +1,43 @@
 //! A library to detect Conda virtual packages present on a system.
+//!
+//! A virtual package represents a package that is injected into the solver to provide system
+//! information to packages. This allows packages to add dependencies on specific system features,
+//! like the platform version, the machines architecture, or the availability of a Cuda driver
+//! with a specific version.
+//!
+//! This library provides both a low- and high level API to detect versions of virtual packages for
+//! the host system.
+//!
+//! To detect all virtual packages for the host system use the [`VirtualPackage::current`] method
+//! which will return a memoized slice of all detected virtual packages. The `VirtualPackage` enum
+//! represents all available virtual package types. Using it provides some flexibility to the
+//! user to not care about which exact virtual packages exist but still allows users to override
+//! specific virtual package behavior. Say for instance you just want to detect the capabilities of
+//! the host system but you still want to restrict the targeted linux version. You can convert an
+//! instance of `VirtualPackage` to `GenericVirtualPackage` which erases any typing for specific
+//! virtual packages.
+//!
+//! Each virtual package is also represented by a struct which can be used to detect the specifics
+//! of one virtual package. For instance the [`Linux::current`] method returns an instance of
+//! `Linux` which contains the current Linux version. It also provides conversions to the higher
+//! level API.
+//!
+//! Finally at the core of the library are detection functions to perform specific capability
+//! detections that are not tied to anything related to virtual packages. See
+//! [`cuda::detect_cuda_version_via_libcuda`] as an example.
 
-mod cuda;
-mod libc;
-mod linux;
-mod osx;
+pub mod cuda;
+pub mod libc;
+pub mod linux;
+pub mod osx;
 
 use once_cell::sync::OnceCell;
 use rattler_conda_types::{Platform, Version};
 use std::str::FromStr;
 
 use crate::osx::ParseOsxVersionError;
-pub use libc::DetectLibCError;
-pub use linux::ParseLinuxVersionError;
+use libc::DetectLibCError;
+use linux::ParseLinuxVersionError;
 
 /// A `GenericVirtualPackage` is a Conda package description that contains a `name` and a
 /// `version` and a `build_string`. See [`VirtualPackage`] for available virtual packages.
@@ -22,6 +48,7 @@ pub struct GenericVirtualPackage {
     pub build_string: String,
 }
 
+/// An enum that represents all virtual package types provide by this library.
 #[derive(Clone, Eq, PartialEq, Hash, Debug)]
 pub enum VirtualPackage {
     /// Available on windows


### PR DESCRIPTION
Based on a discussion in the [Conda issue tracker](https://www.github.com/conda/conda/pull/11667) this implements checking the Cuda driver version via `nvml`.

Also adds a bunch of documentation with regard to what this library is and how to use it.