### PR TITLE
fix(test): derive flaky-test cache key from filename

### DIFF
--- a/crates/rattler_cache/src/package_cache/mod.rs
+++ b/crates/rattler_cache/src/package_cache/mod.rs
@@ -1406,14 +1406,22 @@ mod test {
         let cache = PackageCache::new(packages_dir.path());
 
         let server_url = Url::parse(&format!("http://localhost:{}", addr.port())).unwrap();
+        let url = server_url.join(archive_name).unwrap();
+
+        // The cache key must be derived from the archive's file name only. The
+        // `archive_name` includes the `channel/subdir/` URL prefix so the test
+        // server route matches, but feeding that whole path to
+        // `try_from_filename` would parse path separators into the package name
+        // and produce an unsafe cache key (rejected by `to_path_segment`).
+        let identifier = CondaArchiveIdentifier::try_from_url(&url).unwrap();
 
         let client = ClientBuilder::new(Client::default()).build();
 
         // Do the first request without
         let result = cache
             .get_or_fetch_from_url_with_retry(
-                CondaArchiveIdentifier::try_from_filename(archive_name).unwrap(),
-                server_url.join(archive_name).unwrap(),
+                identifier.clone(),
+                url.clone(),
                 client.clone().into(),
                 DoNotRetryPolicy,
                 None,
@@ -1434,13 +1442,7 @@ mod test {
 
         // The second one should fail after the 2nd try
         let result = cache
-            .get_or_fetch_from_url_with_retry(
-                CondaArchiveIdentifier::try_from_filename(archive_name).unwrap(),
-                server_url.join(archive_name).unwrap(),
-                client.into(),
-                retry_policy,
-                None,
-            )
+            .get_or_fetch_from_url_with_retry(identifier, url, client.into(), retry_policy, None)
             .await;
 
         assert!(result.is_ok());

--- a/crates/rattler_cache/src/package_cache/mod.rs
+++ b/crates/rattler_cache/src/package_cache/mod.rs
@@ -1408,11 +1408,7 @@ mod test {
         let server_url = Url::parse(&format!("http://localhost:{}", addr.port())).unwrap();
         let url = server_url.join(archive_name).unwrap();
 
-        // The cache key must be derived from the archive's file name only. The
-        // `archive_name` includes the `channel/subdir/` URL prefix so the test
-        // server route matches, but feeding that whole path to
-        // `try_from_filename` would parse path separators into the package name
-        // and produce an unsafe cache key (rejected by `to_path_segment`).
+        // Derive the key from the file name only; the path prefix would make an unsafe key.
         let identifier = CondaArchiveIdentifier::try_from_url(&url).unwrap();
 
         let client = ClientBuilder::new(Client::default()).build();


### PR DESCRIPTION
### Description

Fixes the `test_flaky` unit test in `rattler_cache::package_cache` that started failing in CI.

### How Has This Been Tested?

Ran the affected tests locally, which now pass:

`cargo nextest run -p rattler_cache test_flaky`

Both `package_cache::test::test_flaky` and `run_exports_cache::test::test_flaky` pass, along with `cargo fmt` and `cargo clippy`.

### AI Disclosure
- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.

Tools: Claude

### Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added sufficient tests to cover my changes.