### PR TITLE
feat: allow CONDA_OVERRIDE_* environment variables in the CLI

### DIFF
--- a/crates/rattler-bin/src/commands/create.rs
+++ b/crates/rattler-bin/src/commands/create.rs
@@ -242,7 +242,7 @@ pub async fn create(opt: Opt) -> miette::Result<()> {
                 .collect::<miette::Result<Vec<_>>>()?)
         } else {
             rattler_virtual_packages::VirtualPackage::detect(
-                &rattler_virtual_packages::VirtualPackageOverrides::default(),
+                &rattler_virtual_packages::VirtualPackageOverrides::from_env(),
             )
             .map(|vpkgs| {
                 vpkgs

--- a/crates/rattler-bin/src/commands/exec.rs
+++ b/crates/rattler-bin/src/commands/exec.rs
@@ -243,7 +243,7 @@ async fn create_exec_prefix(
 
     // Determine virtual packages of the current platform
     let virtual_packages: Vec<GenericVirtualPackage> =
-        VirtualPackage::detect(&VirtualPackageOverrides::default())
+        VirtualPackage::detect(&VirtualPackageOverrides::from_env())
             .into_diagnostic()
             .context("failed to determine virtual packages")?
             .into_iter()

--- a/crates/rattler-bin/src/commands/prefix.rs
+++ b/crates/rattler-bin/src/commands/prefix.rs
@@ -232,7 +232,7 @@ fn validate_virtual_package_dependencies(
 ) -> miette::Result<()> {
     let virtual_packages = rattler_virtual_packages::VirtualPackages::detect_for_platform(
         platform,
-        &rattler_virtual_packages::VirtualPackageOverrides::default(),
+        &rattler_virtual_packages::VirtualPackageOverrides::from_env(),
     )
     .into_diagnostic()
     .with_context(|| format!("failed to determine virtual packages for {platform}"))?

--- a/crates/rattler-bin/src/commands/virtual_packages.rs
+++ b/crates/rattler-bin/src/commands/virtual_packages.rs
@@ -8,7 +8,7 @@ pub struct Opt {}
 
 pub fn virtual_packages(_opt: Opt) -> miette::Result<()> {
     let virtual_packages =
-        rattler_virtual_packages::VirtualPackage::detect(&VirtualPackageOverrides::default())
+        rattler_virtual_packages::VirtualPackage::detect(&VirtualPackageOverrides::from_env())
             .into_diagnostic()?;
     for package in virtual_packages {
         println!("{}", GenericVirtualPackage::from(package.clone()));


### PR DESCRIPTION
### Description

The `rattler` CLI now respects the `CONDA_OVERRIDE_*` environment variables when detecting virtual packages of the system, matching the behavior of conda. This applies to the `virtual-packages`, `create`, `exec`, and `prefix install` commands.

### How Has This Been Tested?

Existing tests in `rattler-bin` pass, including the virtual package validation test for target platforms. Verified the override behavior by setting `CONDA_OVERRIDE_*` variables and checking the output of the `virtual-packages` command.

### AI Disclosure
- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.

Tools: Claude Code

### Checklist:
- [x] I have performed a self-review of my own code
- [x] I have added sufficient tests to cover my changes.