### PR TITLE
fix(repodata_gateway): disable sharded repodata in run_exports remote test

### DIFF
--- a/crates/rattler_repodata_gateway/src/gateway/mod.rs
+++ b/crates/rattler_repodata_gateway/src/gateway/mod.rs
@@ -1370,7 +1370,20 @@ mod test {
 
     #[tokio::test]
     async fn test_ensure_run_exports_remote_conda_forge() {
-        let gateway = Gateway::new();
+        // conda-forge's sharded repodata now embeds `run_exports` directly in the
+        // records. Disable sharded repodata so that the records are fetched from
+        // `repodata.json` (which does not contain `run_exports`). This ensures the
+        // records start out without `run_exports` and allows us to exercise
+        // `ensure_run_exports`.
+        let gateway = Gateway::builder()
+            .with_channel_config(crate::ChannelConfig {
+                default: SourceConfig {
+                    sharded_enabled: false,
+                    ..SourceConfig::default()
+                },
+                ..crate::ChannelConfig::default()
+            })
+            .finish();
 
         let records = gateway
             .query(


### PR DESCRIPTION
### Description

conda-forge's sharded repodata now embeds `run_exports` inline, so the records returned by the gateway already contained them. This broke the `run_exports_missing` precondition in `test_ensure_run_exports_remote_conda_forge`, failing CI on `main`.

This disables sharded repodata for that test so records are fetched from `repodata.json` (which has no `run_exports`), restoring the test's premise that `ensure_run_exports` must populate the missing data.

### How Has This Been Tested?

`cargo nextest run -p rattler_repodata_gateway --features gateway test_ensure_run_exports_remote_conda_forge` — now passes.

### AI Disclosure
- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.

Tools: Claude

```plaintext
The tests on main (upstream) are currently failing, can you figure out why and fix it?
```

### Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
