### PR TITLE
perf(virtual_packages)!: speed up CUDA virtual package detection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5591,9 +5591,12 @@ dependencies = [
  "rattler_conda_types",
  "regex",
  "serde",
+ "serde_json",
  "temp-env",
+ "tempfile",
  "thiserror 2.0.18",
  "tracing",
+ "windows-sys 0.61.2",
  "winver",
 ]
 

--- a/crates/rattler-bin/src/commands/create.rs
+++ b/crates/rattler-bin/src/commands/create.rs
@@ -243,6 +243,7 @@ pub async fn create(opt: Opt) -> miette::Result<()> {
         } else {
             rattler_virtual_packages::VirtualPackage::detect(
                 &rattler_virtual_packages::VirtualPackageOverrides::from_env(),
+                rattler::default_cache_dir().ok().as_deref(),
             )
             .map(|vpkgs| {
                 vpkgs

--- a/crates/rattler-bin/src/commands/exec.rs
+++ b/crates/rattler-bin/src/commands/exec.rs
@@ -242,13 +242,15 @@ async fn create_exec_prefix(
     tracing::debug!("loaded {} records from repodata", total_records);
 
     // Determine virtual packages of the current platform
-    let virtual_packages: Vec<GenericVirtualPackage> =
-        VirtualPackage::detect(&VirtualPackageOverrides::from_env())
-            .into_diagnostic()
-            .context("failed to determine virtual packages")?
-            .into_iter()
-            .map(GenericVirtualPackage::from)
-            .collect();
+    let virtual_packages: Vec<GenericVirtualPackage> = VirtualPackage::detect(
+        &VirtualPackageOverrides::from_env(),
+        rattler::default_cache_dir().ok().as_deref(),
+    )
+    .into_diagnostic()
+    .context("failed to determine virtual packages")?
+    .into_iter()
+    .map(GenericVirtualPackage::from)
+    .collect();
 
     let solver_task = SolverTask {
         specs: specs.to_vec(),

--- a/crates/rattler-bin/src/commands/prefix.rs
+++ b/crates/rattler-bin/src/commands/prefix.rs
@@ -233,6 +233,7 @@ fn validate_virtual_package_dependencies(
     let virtual_packages = rattler_virtual_packages::VirtualPackages::detect_for_platform(
         platform,
         &rattler_virtual_packages::VirtualPackageOverrides::from_env(),
+        rattler::default_cache_dir().ok().as_deref(),
     )
     .into_diagnostic()
     .with_context(|| format!("failed to determine virtual packages for {platform}"))?

--- a/crates/rattler-bin/src/commands/virtual_packages.rs
+++ b/crates/rattler-bin/src/commands/virtual_packages.rs
@@ -7,9 +7,11 @@ use rattler_virtual_packages::VirtualPackageOverrides;
 pub struct Opt {}
 
 pub fn virtual_packages(_opt: Opt) -> miette::Result<()> {
-    let virtual_packages =
-        rattler_virtual_packages::VirtualPackage::detect(&VirtualPackageOverrides::from_env())
-            .into_diagnostic()?;
+    let virtual_packages = rattler_virtual_packages::VirtualPackage::detect(
+        &VirtualPackageOverrides::from_env(),
+        rattler::default_cache_dir().ok().as_deref(),
+    )
+    .into_diagnostic()?;
     for package in virtual_packages {
         println!("{}", GenericVirtualPackage::from(package.clone()));
     }

--- a/crates/rattler_virtual_packages/Cargo.toml
+++ b/crates/rattler_virtual_packages/Cargo.toml
@@ -17,6 +17,7 @@ once_cell = { workspace = true }
 rattler_conda_types = { workspace = true, default-features = false }
 regex = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
+serde_json = { workspace = true }
 thiserror = { workspace = true }
 tracing = { workspace = true }
 archspec = { workspace = true }
@@ -26,6 +27,8 @@ plist = { workspace = true }
 
 [target.'cfg(target_os="windows")'.dependencies]
 winver = { workspace = true }
+windows-sys = { workspace = true, features = ["Win32_System_SystemInformation"] }
 
 [dev-dependencies]
 temp-env = { workspace = true }
+tempfile = { workspace = true }

--- a/crates/rattler_virtual_packages/src/cuda.rs
+++ b/crates/rattler_virtual_packages/src/cuda.rs
@@ -110,7 +110,6 @@ pub fn cuda_version() -> Option<Version> {
 /// * No CUDA drivers are installed
 /// * No CUDA devices are detected
 /// * Device enumeration fails
-/// * The system is using musl libc (dynamic library loading not supported)
 ///
 /// The result is cached, so subsequent calls are very fast.
 pub fn cuda_arch() -> Option<CudaArchInfo> {
@@ -128,16 +127,15 @@ pub fn cuda_arch() -> Option<CudaArchInfo> {
 /// 3. Initializes NVML and enumerates all CUDA devices to query their compute capabilities
 /// 4. Returns the minimum compute capability across all devices (for `__cuda_arch` virtual package)
 ///
-/// On musl systems, only the version is detected via `nvidia-smi` since dynamic library
+/// On musl systems, both are detected via the `nvidia-smi` command since dynamic library
 /// loading is not supported.
 fn detect_cuda_info() -> CudaInfo {
     if cfg!(target_env = "musl") {
         // Dynamically loading a library is not supported on musl so we have to fall-back to using
-        // the nvidia-smi command. Architecture detection requires library loading, so it's
-        // unavailable on musl.
+        // the nvidia-smi command.
         CudaInfo {
             version: detect_cuda_version_via_nvidia_smi(),
-            arch_info: None,
+            arch_info: detect_cuda_arch_via_nvidia_smi(),
         }
     } else {
         // Detect via NVML, which gives us both version and architecture info from a single library
@@ -484,6 +482,51 @@ fn detect_cuda_version_via_nvidia_smi() -> Option<Version> {
     Version::from_str(version_str).ok()
 }
 
+/// Attempts to detect the CUDA compute capability by executing the "nvidia-smi" command and
+/// querying the `compute_cap` field of every GPU, returning the **minimum** across all devices.
+///
+/// Like [`detect_cuda_version_via_nvidia_smi`] this does not dynamically load a library and thus
+/// also works on musl systems. The `compute_cap` query field requires a reasonably modern driver
+/// (roughly R510+); on older drivers the command fails and `None` is returned.
+fn detect_cuda_arch_via_nvidia_smi() -> Option<CudaArchInfo> {
+    let nvidia_smi_output = Command::new("nvidia-smi")
+        // Query the compute capability of every GPU as plain CSV, one line per GPU.
+        .arg("--query-gpu=compute_cap")
+        .arg("--format=csv,noheader")
+        // See `detect_cuda_version_via_nvidia_smi` for why this variable is removed.
+        .env_remove("CUDA_VISIBLE_DEVICES")
+        .output()
+        .ok()?;
+
+    // On drivers that do not support the `compute_cap` field the command exits with an error.
+    if !nvidia_smi_output.status.success() {
+        return None;
+    }
+
+    let output = String::from_utf8_lossy(&nvidia_smi_output.stdout);
+
+    // Find the minimum compute capability across all devices
+    let mut min_arch: Option<CudaArchInfo> = None;
+    for line in output.lines() {
+        let line = line.trim();
+        let Some((major, minor)) = line.split_once('.') else {
+            continue;
+        };
+        let (Ok(major), Ok(minor)) = (major.parse::<u32>(), minor.parse::<u32>()) else {
+            continue;
+        };
+
+        let is_new_minimum = min_arch
+            .as_ref()
+            .is_none_or(|min| major < min.major || (major == min.major && minor < min.minor));
+        if is_new_minimum {
+            min_arch = Some(CudaArchInfo { major, minor });
+        }
+    }
+
+    min_arch
+}
+
 #[cfg(test)]
 mod test {
     use super::*;
@@ -498,6 +541,12 @@ mod test {
     pub fn doesnt_crash_nvidia_smi() {
         let version = detect_cuda_version_via_nvidia_smi();
         println!("Cuda {version:?}");
+    }
+
+    #[test]
+    pub fn doesnt_crash_nvidia_smi_arch() {
+        let arch = detect_cuda_arch_via_nvidia_smi();
+        println!("Cuda arch {arch:?}");
     }
 
     #[test]

--- a/crates/rattler_virtual_packages/src/cuda.rs
+++ b/crates/rattler_virtual_packages/src/cuda.rs
@@ -331,24 +331,15 @@ pub fn detect_cuda_version() -> Option<Version> {
 /// Although the required methods in the runtime are not implemented on much older machines it is
 /// considered old enough to be usable for our use case. Since Conda doesn't provide old versions of
 /// the CUDA SDK anyway this is considered a non-issue.
+///
+/// `nvmlSystemGetCudaDriverVersion` reads the version straight from the CUDA driver library and,
+/// unlike most NVML functions, does not require `nvmlInit`. We therefore skip initialization, which
+/// avoids the expensive driver handshake / GPU attach that makes `nvmlInit` slow on Windows.
 pub fn detect_cuda_version_via_nvml() -> Option<Version> {
     // Try to open the library
     let library = nvml_library_paths()
         .iter()
         .find_map(|path| unsafe { libloading::Library::new(*path).ok() })?;
-
-    // Get the initialization function. We first try to get `nvmlInit_v2` but if we can't find that
-    // we use the `nvmlInit` function.
-    let nvml_init: Symbol<'_, unsafe extern "C" fn() -> c_int> = unsafe {
-        library
-            .get(b"nvmlInit_v2\0")
-            .or_else(|_| library.get(b"nvmlInit\0"))
-    }
-    .ok()?;
-
-    // Find the shutdown function
-    let nvml_shutdown: Symbol<'_, unsafe extern "C" fn() -> c_int> =
-        unsafe { library.get(b"nvmlShutdown\0") }.ok()?;
 
     // Find the `nvmlSystemGetCudaDriverVersion_v2` function. If that function cannot be found, fall
     // back to the `nvmlSystemGetCudaDriverVersion` function instead.
@@ -360,18 +351,9 @@ pub fn detect_cuda_version_via_nvml() -> Option<Version> {
         }
         .ok()?;
 
-    // Call the initialization function
-    if unsafe { nvml_init() } != 0 {
-        return None;
-    }
-
-    // Get the version
+    // Query the version without initializing NVML.
     let mut cuda_driver_version = MaybeUninit::uninit();
     let result = unsafe { nvml_system_get_cuda_driver_version(cuda_driver_version.as_mut_ptr()) };
-
-    // Call the shutdown function (don't care about the result of the function). Whatever happens,
-    // after calling `nvmlInit` we have to call `nvmlShutdown`.
-    let _ = unsafe { nvml_shutdown() };
 
     // If the call failed we dont have a version
     if result != 0 {

--- a/crates/rattler_virtual_packages/src/cuda.rs
+++ b/crates/rattler_virtual_packages/src/cuda.rs
@@ -7,7 +7,7 @@
 //! The CUDA driver version represents the maximum CUDA version supported by the installed
 //! NVIDIA drivers. This is detected via:
 //!
-//! * CUDA driver library (libcuda): Standard method
+//! * NVIDIA Management Library (NVML): Standard method
 //! * nvidia-smi command: Fallback on musl systems where dynamic library loading is not supported
 //!
 //! ## CUDA Compute Capability (`__cuda_arch`)
@@ -21,7 +21,8 @@ use rattler_conda_types::Version;
 use std::process::Command;
 use std::{
     mem::MaybeUninit,
-    os::raw::{c_int, c_uint, c_ulong},
+    os::raw::{c_int, c_uint, c_ulong, c_void},
+    ptr,
     str::FromStr,
 };
 
@@ -119,14 +120,13 @@ pub fn cuda_arch() -> Option<CudaArchInfo> {
 /// Detects comprehensive CUDA information from the current system.
 ///
 /// This function performs unified detection of both CUDA driver version and compute
-/// capability by loading the CUDA library once and querying all necessary information.
+/// capability by loading NVML once and querying all necessary information.
 ///
 /// The detection process:
-/// 1. Attempts to load the CUDA driver library (`libcuda`)
-/// 2. Initializes the CUDA driver API
-/// 3. Queries the driver version (for `__cuda` virtual package)
-/// 4. Enumerates all CUDA devices and queries their compute capabilities
-/// 5. Returns the minimum compute capability across all devices (for `__cuda_arch` virtual package)
+/// 1. Attempts to load NVML (`libnvidia-ml`/`nvml.dll`)
+/// 2. Queries the driver version (for `__cuda` virtual package); this does not require init
+/// 3. Initializes NVML and enumerates all CUDA devices to query their compute capabilities
+/// 4. Returns the minimum compute capability across all devices (for `__cuda_arch` virtual package)
 ///
 /// On musl systems, only the version is detected via `nvidia-smi` since dynamic library
 /// loading is not supported.
@@ -140,173 +140,159 @@ fn detect_cuda_info() -> CudaInfo {
             arch_info: None,
         }
     } else {
-        // Try to detect via libcuda which allows us to get both version and architecture info
-        detect_cuda_info_via_libcuda()
+        // Detect via NVML, which gives us both version and architecture info from a single library
+        // and, unlike libcuda, is not affected by `CUDA_VISIBLE_DEVICES`.
+        detect_cuda_info_via_nvml()
     }
 }
 
-/// Detects CUDA version and architecture information via the CUDA driver library.
+/// Detects CUDA version and architecture information via the NVIDIA Management Library.
 ///
-/// This function loads `libcuda` and uses the CUDA Driver API to query both the driver
-/// version and device compute capabilities. This is more efficient than separate detection
-/// because the library is loaded only once.
+/// The library is loaded once and used to query both the driver version and device compute
+/// capabilities. NVML is preferred over libcuda because it is not affected by
+/// `CUDA_VISIBLE_DEVICES`.
 ///
 /// Returns a `CudaInfo` struct where:
 /// * `version` is `None` if the driver version cannot be determined
 /// * `arch_info` is `None` if no devices are present or device queries fail
-fn detect_cuda_info_via_libcuda() -> CudaInfo {
-    // Try to open the CUDA library
-    let cuda_library = match cuda_library_paths()
+fn detect_cuda_info_via_nvml() -> CudaInfo {
+    let Some(library) = nvml_library_paths()
         .iter()
         .find_map(|path| unsafe { Library::new(*path).ok() })
-    {
-        Some(lib) => lib,
-        None => {
-            return CudaInfo {
-                version: None,
-                arch_info: None,
-            };
-        }
-    };
-
-    // Get entry points from the library
-    let cu_init: Symbol<'_, unsafe extern "C" fn(c_uint) -> c_ulong> =
-        match unsafe { cuda_library.get(b"cuInit\0") } {
-            Ok(init) => init,
-            Err(_) => {
-                return CudaInfo {
-                    version: None,
-                    arch_info: None,
-                };
-            }
-        };
-
-    // Initialize the CUDA library
-    if unsafe { cu_init(0) } != 0 {
+    else {
         return CudaInfo {
             version: None,
             arch_info: None,
         };
-    }
+    };
 
-    // Detect the driver version (can succeed even without devices)
-    let version = detect_cuda_version_from_library(&cuda_library);
+    // The version can be queried without initializing NVML and even without any devices present.
+    let version = cuda_version_from_nvml_library(&library);
 
-    // Detect architecture info (requires devices to be present)
-    let arch_info = detect_cuda_arch_from_library(&cuda_library);
+    // Compute capability requires enumerating devices, which needs NVML to be initialized.
+    let arch_info = detect_cuda_arch_via_nvml(&library);
 
     CudaInfo { version, arch_info }
 }
 
-/// Detects CUDA driver version from an already-loaded CUDA library.
+/// Queries the CUDA driver version from an already-loaded NVML library.
 ///
-/// This function queries the CUDA driver version using `cuDriverGetVersion`.
-/// The version can be detected even if no GPU devices are present on the system.
-fn detect_cuda_version_from_library(cuda_library: &Library) -> Option<Version> {
-    let cu_driver_get_version: Symbol<'_, unsafe extern "C" fn(*mut c_int) -> c_ulong> =
-        unsafe { cuda_library.get(b"cuDriverGetVersion\0") }.ok()?;
+/// `nvmlSystemGetCudaDriverVersion` reads the version straight from the CUDA driver library and
+/// does not require `nvmlInit`.
+fn cuda_version_from_nvml_library(library: &Library) -> Option<Version> {
+    // Find the `nvmlSystemGetCudaDriverVersion_v2` function. If that function cannot be found, fall
+    // back to the `nvmlSystemGetCudaDriverVersion` function instead.
+    let nvml_system_get_cuda_driver_version: Symbol<'_, unsafe extern "C" fn(*mut c_int) -> c_int> =
+        unsafe {
+            library
+                .get(b"nvmlSystemGetCudaDriverVersion_v2\0")
+                .or_else(|_| library.get(b"nvmlSystemGetCudaDriverVersion\0"))
+        }
+        .ok()?;
 
-    // Get the version from the library
-    let mut version_int = MaybeUninit::uninit();
-    if unsafe { cu_driver_get_version(version_int.as_mut_ptr()) != 0 } {
+    let mut cuda_driver_version = MaybeUninit::uninit();
+    if unsafe { nvml_system_get_cuda_driver_version(cuda_driver_version.as_mut_ptr()) } != 0 {
         return None;
     }
-    let version = unsafe { version_int.assume_init() };
+    let version = unsafe { cuda_driver_version.assume_init() };
 
     // Convert the version integer to a version string
     Version::from_str(&format!("{}.{}", version / 1000, (version % 1000) / 10)).ok()
 }
 
-/// Detects CUDA compute capability from an already-loaded CUDA library.
+/// Detects CUDA compute capability from an already-loaded NVML library.
 ///
-/// This function enumerates all CUDA devices and queries their compute capabilities,
-/// returning the **minimum** compute capability found across all devices along with
-/// the name of the device that has this minimum capability.
+/// Initializes NVML, enumerates all devices, and returns the **minimum** compute capability across
+/// them. Unlike the version query, reading device compute capabilities requires NVML to be
+/// initialized (with the GPUs attached).
 ///
-/// Returns `None` if:
-/// * No CUDA devices are detected (`cuDeviceGetCount` returns 0)
-/// * Device enumeration fails
-/// * Any of the required CUDA Driver API functions cannot be loaded
-fn detect_cuda_arch_from_library(cuda_library: &Library) -> Option<CudaArchInfo> {
-    // CUDA device attribute constants for querying compute capability
-    const CU_DEVICE_ATTRIBUTE_COMPUTE_CAPABILITY_MAJOR: c_int = 75;
-    const CU_DEVICE_ATTRIBUTE_COMPUTE_CAPABILITY_MINOR: c_int = 76;
+/// Returns `None` if NVML cannot be initialized, no devices are present, or device queries fail.
+fn detect_cuda_arch_via_nvml(library: &Library) -> Option<CudaArchInfo> {
+    // NVML device handle (`nvmlDevice_t`) is an opaque pointer.
+    type NvmlDevice = *mut c_void;
 
-    // Get required function pointers from the library
-    let cu_device_get_count: Symbol<'_, unsafe extern "C" fn(*mut c_int) -> c_ulong> =
-        unsafe { cuda_library.get(b"cuDeviceGetCount\0") }.ok()?;
+    let nvml_init: Symbol<'_, unsafe extern "C" fn() -> c_int> = unsafe {
+        library
+            .get(b"nvmlInit_v2\0")
+            .or_else(|_| library.get(b"nvmlInit\0"))
+    }
+    .ok()?;
 
-    let cu_device_get: Symbol<'_, unsafe extern "C" fn(*mut c_int, c_int) -> c_ulong> =
-        unsafe { cuda_library.get(b"cuDeviceGet\0") }.ok()?;
+    let nvml_shutdown: Symbol<'_, unsafe extern "C" fn() -> c_int> =
+        unsafe { library.get(b"nvmlShutdown\0") }.ok()?;
 
-    let cu_device_get_attribute: Symbol<
+    let nvml_device_get_count: Symbol<'_, unsafe extern "C" fn(*mut c_uint) -> c_int> = unsafe {
+        library
+            .get(b"nvmlDeviceGetCount_v2\0")
+            .or_else(|_| library.get(b"nvmlDeviceGetCount\0"))
+    }
+    .ok()?;
+
+    let nvml_device_get_handle_by_index: Symbol<
         '_,
-        unsafe extern "C" fn(*mut c_int, c_int, c_int) -> c_ulong,
-    > = unsafe { cuda_library.get(b"cuDeviceGetAttribute\0") }.ok()?;
+        unsafe extern "C" fn(c_uint, *mut NvmlDevice) -> c_int,
+    > = unsafe {
+        library
+            .get(b"nvmlDeviceGetHandleByIndex_v2\0")
+            .or_else(|_| library.get(b"nvmlDeviceGetHandleByIndex\0"))
+    }
+    .ok()?;
 
-    // Get the number of CUDA devices
-    let mut device_count = MaybeUninit::uninit();
-    if unsafe { cu_device_get_count(device_count.as_mut_ptr()) } != 0 {
+    let nvml_device_get_cuda_compute_capability: Symbol<
+        '_,
+        unsafe extern "C" fn(NvmlDevice, *mut c_int, *mut c_int) -> c_int,
+    > = unsafe { library.get(b"nvmlDeviceGetCudaComputeCapability\0") }.ok()?;
+
+    if unsafe { nvml_init() } != 0 {
         return None;
     }
-    let device_count = unsafe { device_count.assume_init() };
 
-    // No devices found
-    if device_count == 0 {
-        return None;
-    }
-
-    // Iterate through all devices to find the minimum compute capability
-    let mut min_arch: Option<CudaArchInfo> = None;
-
-    for device_idx in 0..device_count {
-        // Get device handle
-        let mut device = MaybeUninit::uninit();
-        if unsafe { cu_device_get(device.as_mut_ptr(), device_idx) } != 0 {
-            continue;
+    // Enumerate devices to find the minimum compute capability. Wrapped in a closure so we always
+    // reach the `nvmlShutdown` call below regardless of the outcome.
+    let min_arch = (|| {
+        let mut device_count = MaybeUninit::uninit();
+        if unsafe { nvml_device_get_count(device_count.as_mut_ptr()) } != 0 {
+            return None;
         }
-        let device = unsafe { device.assume_init() };
+        let device_count = unsafe { device_count.assume_init() };
 
-        // Get compute capability major version
-        let mut cc_major = MaybeUninit::uninit();
-        if unsafe {
-            cu_device_get_attribute(
-                cc_major.as_mut_ptr(),
-                CU_DEVICE_ATTRIBUTE_COMPUTE_CAPABILITY_MAJOR,
-                device,
-            )
-        } != 0
-        {
-            continue;
-        }
-        let cc_major = unsafe { cc_major.assume_init() } as u32;
+        let mut min_arch: Option<CudaArchInfo> = None;
+        for device_idx in 0..device_count {
+            let mut device: NvmlDevice = ptr::null_mut();
+            if unsafe { nvml_device_get_handle_by_index(device_idx, &mut device) } != 0 {
+                continue;
+            }
 
-        // Get compute capability minor version
-        let mut cc_minor = MaybeUninit::uninit();
-        if unsafe {
-            cu_device_get_attribute(
-                cc_minor.as_mut_ptr(),
-                CU_DEVICE_ATTRIBUTE_COMPUTE_CAPABILITY_MINOR,
-                device,
-            )
-        } != 0
-        {
-            continue;
-        }
-        let cc_minor = unsafe { cc_minor.assume_init() } as u32;
+            let mut cc_major = MaybeUninit::uninit();
+            let mut cc_minor = MaybeUninit::uninit();
+            if unsafe {
+                nvml_device_get_cuda_compute_capability(
+                    device,
+                    cc_major.as_mut_ptr(),
+                    cc_minor.as_mut_ptr(),
+                )
+            } != 0
+            {
+                continue;
+            }
+            let cc_major = unsafe { cc_major.assume_init() } as u32;
+            let cc_minor = unsafe { cc_minor.assume_init() } as u32;
 
-        // Check if this is the minimum compute capability so far
-        let is_new_minimum = min_arch.as_ref().is_none_or(|min| {
-            cc_major < min.major || (cc_major == min.major && cc_minor < min.minor)
-        });
-
-        if is_new_minimum {
-            min_arch = Some(CudaArchInfo {
-                major: cc_major,
-                minor: cc_minor,
+            let is_new_minimum = min_arch.as_ref().is_none_or(|min| {
+                cc_major < min.major || (cc_major == min.major && cc_minor < min.minor)
             });
+            if is_new_minimum {
+                min_arch = Some(CudaArchInfo {
+                    major: cc_major,
+                    minor: cc_minor,
+                });
+            }
         }
-    }
+        min_arch
+    })();
+
+    // Whatever happens, after initializing NVML we have to call `nvmlShutdown`.
+    let _ = unsafe { nvml_shutdown() };
 
     min_arch
 }
@@ -341,30 +327,7 @@ pub fn detect_cuda_version_via_nvml() -> Option<Version> {
         .iter()
         .find_map(|path| unsafe { libloading::Library::new(*path).ok() })?;
 
-    // Find the `nvmlSystemGetCudaDriverVersion_v2` function. If that function cannot be found, fall
-    // back to the `nvmlSystemGetCudaDriverVersion` function instead.
-    let nvml_system_get_cuda_driver_version: Symbol<'_, unsafe extern "C" fn(*mut c_int) -> c_int> =
-        unsafe {
-            library
-                .get(b"nvmlSystemGetCudaDriverVersion_v2\0")
-                .or_else(|_| library.get(b"nvmlSystemGetCudaDriverVersion\0"))
-        }
-        .ok()?;
-
-    // Query the version without initializing NVML.
-    let mut cuda_driver_version = MaybeUninit::uninit();
-    let result = unsafe { nvml_system_get_cuda_driver_version(cuda_driver_version.as_mut_ptr()) };
-
-    // If the call failed we dont have a version
-    if result != 0 {
-        return None;
-    }
-
-    // We can assume the value is initialized by the `nvmlSystemGetCudaDriverVersion` function.
-    let version = unsafe { cuda_driver_version.assume_init() };
-
-    // Convert the version integer to a version string
-    Version::from_str(&format!("{}.{}", version / 1000, (version % 1000) / 10)).ok()
+    cuda_version_from_nvml_library(&library)
 }
 
 /// Returns platform specific set of search paths for the CUDA library.

--- a/crates/rattler_virtual_packages/src/cuda.rs
+++ b/crates/rattler_virtual_packages/src/cuda.rs
@@ -22,9 +22,12 @@ use std::process::Command;
 use std::{
     mem::MaybeUninit,
     os::raw::{c_int, c_uint, c_ulong, c_void},
+    path::Path,
     ptr,
     str::FromStr,
 };
+
+mod cache;
 
 /// Validates that a string is in the format "major.minor" where both parts are digits.
 ///
@@ -88,17 +91,32 @@ pub struct CudaInfo {
 ///
 /// This is more efficient than calling [`cuda_version`] and [`cuda_arch`] separately
 /// because the CUDA library is loaded only once.
-pub fn cuda_info() -> &'static CudaInfo {
+///
+/// `cache_dir` is the directory used to cache the detection result across processes until the
+/// next reboot; pass `None` to disable the on-disk cache. Detection runs at most once per
+/// process, so the cache directory is only used by the first call.
+pub fn cuda_info(cache_dir: Option<&Path>) -> &'static CudaInfo {
     static DETECTED_CUDA_INFO: OnceCell<CudaInfo> = OnceCell::new();
-    DETECTED_CUDA_INFO.get_or_init(detect_cuda_info)
+    DETECTED_CUDA_INFO.get_or_init(|| {
+        // Initializing the driver to detect the GPU can be slow, so the result is cached on disk
+        // and reused until the next reboot.
+        if let Some(info) = cache_dir.and_then(cache::read) {
+            return info;
+        }
+        let info = detect_cuda_info();
+        if let Some(cache_dir) = cache_dir {
+            cache::write(cache_dir, &info);
+        }
+        info
+    })
 }
 
 /// Returns the maximum CUDA version available on the current platform.
 ///
 /// This corresponds to the `__cuda` virtual package. The result is cached,
-/// so subsequent calls are very fast.
-pub fn cuda_version() -> Option<Version> {
-    cuda_info().version.clone()
+/// so subsequent calls are very fast. See [`cuda_info`] for the `cache_dir` semantics.
+pub fn cuda_version(cache_dir: Option<&Path>) -> Option<Version> {
+    cuda_info(cache_dir).version.clone()
 }
 
 /// Returns CUDA compute capability information from the current platform.
@@ -111,9 +129,10 @@ pub fn cuda_version() -> Option<Version> {
 /// * No CUDA devices are detected
 /// * Device enumeration fails
 ///
-/// The result is cached, so subsequent calls are very fast.
-pub fn cuda_arch() -> Option<CudaArchInfo> {
-    cuda_info().arch_info.clone()
+/// The result is cached, so subsequent calls are very fast. See [`cuda_info`] for the `cache_dir`
+/// semantics.
+pub fn cuda_arch(cache_dir: Option<&Path>) -> Option<CudaArchInfo> {
+    cuda_info(cache_dir).arch_info.clone()
 }
 
 /// Detects comprehensive CUDA information from the current system.
@@ -551,7 +570,7 @@ mod test {
 
     #[test]
     pub fn test_cuda_info() {
-        let info = cuda_info();
+        let info = cuda_info(None);
         println!("CUDA Info: {info:?}");
         if let Some(ref arch) = info.arch_info {
             println!("  Compute capability: {}.{}", arch.major, arch.minor);
@@ -560,8 +579,76 @@ mod test {
 
     #[test]
     pub fn test_cuda_arch() {
-        let arch = cuda_arch();
+        let arch = cuda_arch(None);
         println!("CUDA Arch: {arch:?}");
+    }
+
+    #[test]
+    fn test_cache_roundtrip() {
+        let dir = tempfile::tempdir().unwrap();
+
+        // Nothing cached yet
+        assert!(cache::read(dir.path()).is_none());
+
+        // Negative results are not cached
+        cache::write(
+            dir.path(),
+            &CudaInfo {
+                version: None,
+                arch_info: None,
+            },
+        );
+        assert!(cache::read(dir.path()).is_none());
+
+        let info = CudaInfo {
+            version: Some(Version::from_str("12.4").unwrap()),
+            arch_info: Some(CudaArchInfo { major: 8, minor: 6 }),
+        };
+        cache::write(dir.path(), &info);
+
+        if cache::BootId::current().is_none() {
+            // Cannot key the cache without a boot id on this platform
+            return;
+        }
+        let cached = cache::read(dir.path()).unwrap();
+        assert_eq!(cached.version, info.version);
+        assert_eq!(cached.arch_info, info.arch_info);
+    }
+
+    #[test]
+    fn test_cache_invalidated_after_driver_change() {
+        let dir = tempfile::tempdir().unwrap();
+        cache::write(
+            dir.path(),
+            &CudaInfo {
+                version: Some(Version::from_str("12.4").unwrap()),
+                arch_info: None,
+            },
+        );
+        let path = dir.path().join("cuda-info-v1.json");
+        let Ok(content) = std::fs::read_to_string(&path) else {
+            // Nothing was cached because this platform has no boot id
+            return;
+        };
+
+        // A cache file written with a different driver installed is ignored
+        let mut cached: serde_json::Value = serde_json::from_str(&content).unwrap();
+        cached["driver_fingerprint"] = "definitely-stale".into();
+        std::fs::write(&path, serde_json::to_string(&cached).unwrap()).unwrap();
+        assert!(cache::read(dir.path()).is_none());
+    }
+
+    #[test]
+    fn test_cache_invalidated_after_reboot() {
+        let dir = tempfile::tempdir().unwrap();
+
+        // A cache file from a different boot session is ignored
+        std::fs::write(
+            dir.path().join("cuda-info-v1.json"),
+            r#"{"boot_id":"not-the-current-boot","driver_fingerprint":null,"version":"12.4","arch":[8,6]}"#,
+        )
+        .unwrap();
+        assert!(cache::read(dir.path()).is_none());
     }
 
     #[test]

--- a/crates/rattler_virtual_packages/src/cuda/cache.rs
+++ b/crates/rattler_virtual_packages/src/cuda/cache.rs
@@ -1,0 +1,164 @@
+//! On-disk cache for detected CUDA information, valid for the current boot session.
+//!
+//! The installed driver and GPUs only change with a reboot in practice, so the cache is keyed on
+//! an identifier of the current boot session. Reads and writes are best-effort: any failure simply
+//! results in a fresh detection. Delete the file or use the `CONDA_OVERRIDE_CUDA*` variables to
+//! bypass it.
+
+use super::{CudaArchInfo, CudaInfo};
+use rattler_conda_types::Version;
+use serde::{Deserialize, Serialize};
+use std::{path::Path, str::FromStr};
+
+const CACHE_FILE_NAME: &str = "cuda-info-v1.json";
+
+/// Identifies a single boot session of the machine.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(transparent)]
+pub(super) struct BootId(String);
+
+impl BootId {
+    /// Returns the identifier of the current boot session, or `None` if it cannot be determined
+    /// (in which case no caching takes place).
+    pub(super) fn current() -> Option<Self> {
+        #[cfg(target_os = "linux")]
+        {
+            // The kernel generates a fresh UUID on every boot.
+            let id = std::fs::read_to_string("/proc/sys/kernel/random/boot_id").ok()?;
+            Some(Self(id.trim().to_owned()))
+        }
+        #[cfg(target_os = "windows")]
+        {
+            // Windows has no boot UUID; derive the boot time from the current time and the
+            // uptime instead. The derivation drifts a little, which `matches` absorbs.
+            let uptime_secs =
+                unsafe { windows_sys::Win32::System::SystemInformation::GetTickCount64() } / 1000;
+            let now_secs = std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .ok()?
+                .as_secs();
+            Some(Self(now_secs.checked_sub(uptime_secs)?.to_string()))
+        }
+        #[cfg(not(any(target_os = "linux", target_os = "windows")))]
+        {
+            None
+        }
+    }
+
+    /// Returns true if both identifiers refer to the same boot session.
+    fn matches(&self, other: &Self) -> bool {
+        #[cfg(target_os = "windows")]
+        {
+            // The derived boot time can drift a few seconds between processes. A real reboot
+            // shifts it by at least the previous uptime, which is far larger than this tolerance.
+            const BOOT_TIME_TOLERANCE_SECS: u64 = 120;
+            if let (Ok(a), Ok(b)) = (self.0.parse::<u64>(), other.0.parse::<u64>()) {
+                return a.abs_diff(b) <= BOOT_TIME_TOLERANCE_SECS;
+            }
+        }
+        self == other
+    }
+}
+
+#[derive(Serialize, Deserialize)]
+struct CacheFile {
+    /// The boot session during which detection ran.
+    boot_id: BootId,
+    /// Fingerprint of the installed driver when detection ran.
+    driver_fingerprint: Option<String>,
+    version: String,
+    arch: Option<(u32, u32)>,
+}
+
+/// Returns a fingerprint of the installed NVIDIA driver, or `None` if it cannot be determined.
+///
+/// Drivers can be updated without a reboot, so the boot session alone is not enough to key the
+/// cache on.
+fn driver_fingerprint() -> Option<String> {
+    #[cfg(target_os = "linux")]
+    {
+        // The version of the loaded kernel module, which changes when the driver is updated and
+        // the module is reloaded.
+        Some(
+            std::fs::read_to_string("/sys/module/nvidia/version")
+                .ok()?
+                .trim()
+                .to_owned(),
+        )
+    }
+    #[cfg(target_os = "windows")]
+    {
+        // Driver updates on Windows usually complete without a reboot but replace nvml.dll.
+        let windir = std::env::var_os("WINDIR")?;
+        let metadata =
+            std::fs::metadata(Path::new(&windir).join("System32").join("nvml.dll")).ok()?;
+        let mtime = metadata
+            .modified()
+            .ok()?
+            .duration_since(std::time::UNIX_EPOCH)
+            .ok()?;
+        Some(format!("{}:{}", mtime.as_secs(), metadata.len()))
+    }
+    #[cfg(not(any(target_os = "linux", target_os = "windows")))]
+    {
+        None
+    }
+}
+
+pub(super) fn read(cache_dir: &Path) -> Option<CudaInfo> {
+    let path = cache_dir.join(CACHE_FILE_NAME);
+    let Ok(content) = std::fs::read_to_string(&path) else {
+        tracing::debug!("no CUDA info cache found at {}", path.display());
+        return None;
+    };
+    let Ok(cached) = serde_json::from_str::<CacheFile>(&content) else {
+        tracing::debug!("ignoring invalid CUDA info cache at {}", path.display());
+        return None;
+    };
+    if !cached.boot_id.matches(&BootId::current()?) {
+        tracing::debug!("ignoring CUDA info cache from a previous boot session");
+        return None;
+    }
+    if cached.driver_fingerprint != driver_fingerprint() {
+        tracing::debug!("ignoring CUDA info cache because the driver changed");
+        return None;
+    }
+    let version = Version::from_str(&cached.version).ok()?;
+    tracing::debug!("using CUDA info cached at {}", path.display());
+    Some(CudaInfo {
+        version: Some(version),
+        arch_info: cached
+            .arch
+            .map(|(major, minor)| CudaArchInfo { major, minor }),
+    })
+}
+
+pub(super) fn write(cache_dir: &Path, info: &CudaInfo) {
+    // Only cache when a driver was found: detection without a driver is fast anyway, and not
+    // caching the negative result means a freshly installed driver is picked up immediately.
+    let Some(version) = &info.version else { return };
+    let Some(boot_id) = BootId::current() else {
+        return;
+    };
+    if std::fs::create_dir_all(cache_dir).is_err() {
+        return;
+    }
+    let cached = CacheFile {
+        boot_id,
+        driver_fingerprint: driver_fingerprint(),
+        version: version.to_string(),
+        arch: info.arch_info.as_ref().map(|arch| (arch.major, arch.minor)),
+    };
+    let Ok(content) = serde_json::to_string(&cached) else {
+        return;
+    };
+    // Write-then-rename so concurrent readers never see a partial file.
+    let path = cache_dir.join(CACHE_FILE_NAME);
+    let tmp = path.with_extension(format!("json.{}", std::process::id()));
+    match std::fs::write(&tmp, content).and_then(|()| std::fs::rename(&tmp, &path)) {
+        Ok(()) => tracing::debug!("cached CUDA info at {}", path.display()),
+        Err(_) => {
+            let _ = std::fs::remove_file(&tmp);
+        }
+    }
+}

--- a/crates/rattler_virtual_packages/src/lib.rs
+++ b/crates/rattler_virtual_packages/src/lib.rs
@@ -43,6 +43,7 @@ use std::{
     env, fmt,
     fmt::Display,
     hash::{Hash, Hasher},
+    path::Path,
     str::FromStr,
     sync::Arc,
 };
@@ -251,9 +252,16 @@ impl VirtualPackages {
 
     /// Detect the virtual packages of the current system with the given
     /// overrides.
-    pub fn detect(overrides: &VirtualPackageOverrides) -> Result<Self, DetectVirtualPackageError> {
-        let cuda = Cuda::detect(overrides.cuda.as_ref())?;
-        let mut cuda_arch = CudaArch::detect(overrides.cuda_arch.as_ref())?;
+    ///
+    /// `cache_dir` is used to cache expensive detection results (currently CUDA) on disk across
+    /// processes; pass `None` to disable the on-disk cache.
+    pub fn detect(
+        overrides: &VirtualPackageOverrides,
+        cache_dir: Option<&Path>,
+    ) -> Result<Self, DetectVirtualPackageError> {
+        let cuda = Cuda::detect_with_cache_dir(overrides.cuda.as_ref(), cache_dir)?;
+        let mut cuda_arch =
+            CudaArch::detect_with_cache_dir(overrides.cuda_arch.as_ref(), cache_dir)?;
 
         // Enforce CEP requirement: __cuda_arch must be absent when __cuda is absent
         if cuda.is_none() {
@@ -294,8 +302,9 @@ impl VirtualPackages {
     pub fn detect_for_platform(
         platform: Platform,
         overrides: &VirtualPackageOverrides,
+        cache_dir: Option<&Path>,
     ) -> Result<Self, DetectVirtualPackageError> {
-        let virtual_packages = Self::detect(overrides)?;
+        let virtual_packages = Self::detect(overrides, cache_dir)?;
         if platform == Platform::current() {
             // If we're targeting the current platform, just return the detected packages
             Ok(virtual_packages)
@@ -392,15 +401,18 @@ impl VirtualPackage {
         note = "Use `VirtualPackage::detect(&VirtualPackageOverrides::default())` instead."
     )]
     pub fn current() -> Result<Vec<Self>, DetectVirtualPackageError> {
-        Self::detect(&VirtualPackageOverrides::default())
+        Self::detect(&VirtualPackageOverrides::default(), None)
     }
 
     /// Detect the virtual packages of the current system with the given
     /// overrides.
+    ///
+    /// See [`VirtualPackages::detect`] for the `cache_dir` semantics.
     pub fn detect(
         overrides: &VirtualPackageOverrides,
+        cache_dir: Option<&Path>,
     ) -> Result<Vec<Self>, DetectVirtualPackageError> {
-        Ok(VirtualPackages::detect(overrides)?
+        Ok(VirtualPackages::detect(overrides, cache_dir)?
             .into_virtual_packages()
             .collect())
     }
@@ -603,8 +615,22 @@ pub struct Cuda {
 
 impl Cuda {
     /// Returns the maximum Cuda version available on the current platform.
-    pub fn current() -> Option<Self> {
-        cuda::cuda_version().map(|version| Self { version })
+    ///
+    /// See [`cuda::cuda_info`] for the `cache_dir` semantics.
+    pub fn current(cache_dir: Option<&Path>) -> Option<Self> {
+        cuda::cuda_version(cache_dir).map(|version| Self { version })
+    }
+
+    /// Detect the Cuda virtual package with the given override, using `cache_dir` for the on-disk
+    /// detection cache.
+    pub fn detect_with_cache_dir(
+        ov: Option<&Override>,
+        cache_dir: Option<&Path>,
+    ) -> Result<Option<Self>, DetectVirtualPackageError> {
+        match ov {
+            Some(ov) => Self::detect_with_fallback(ov, || Ok(Self::current(cache_dir))),
+            None => Ok(Self::current(cache_dir)),
+        }
     }
 }
 
@@ -621,7 +647,7 @@ impl EnvOverride for Cuda {
         })
     }
     fn detect_from_host() -> Result<Option<Self>, DetectVirtualPackageError> {
-        Ok(Self::current())
+        Ok(Self::current(None))
     }
     const DEFAULT_ENV_NAME: &'static str = "CONDA_OVERRIDE_CUDA";
 }
@@ -673,11 +699,25 @@ impl CudaArch {
     /// * No CUDA drivers are installed
     /// * No CUDA devices are detected
     /// * Device enumeration fails
-    pub fn current() -> Option<Self> {
-        cuda::cuda_arch().map(|arch_info| Self {
+    ///
+    /// See [`cuda::cuda_info`] for the `cache_dir` semantics.
+    pub fn current(cache_dir: Option<&Path>) -> Option<Self> {
+        cuda::cuda_arch(cache_dir).map(|arch_info| Self {
             version: Version::from_str(&format!("{}.{}", arch_info.major, arch_info.minor))
                 .unwrap_or_else(|_| Version::major(u64::from(arch_info.major))),
         })
+    }
+
+    /// Detect the CUDA compute capability virtual package with the given override, using
+    /// `cache_dir` for the on-disk detection cache.
+    pub fn detect_with_cache_dir(
+        ov: Option<&Override>,
+        cache_dir: Option<&Path>,
+    ) -> Result<Option<Self>, DetectVirtualPackageError> {
+        match ov {
+            Some(ov) => Self::detect_with_fallback(ov, || Ok(Self::current(cache_dir))),
+            None => Ok(Self::current(cache_dir)),
+        }
     }
 }
 
@@ -695,7 +735,7 @@ impl EnvOverride for CudaArch {
     }
 
     fn detect_from_host() -> Result<Option<Self>, DetectVirtualPackageError> {
-        Ok(Self::current())
+        Ok(Self::current(None))
     }
 
     const DEFAULT_ENV_NAME: &'static str = "CONDA_OVERRIDE_CUDA_ARCH";
@@ -994,7 +1034,7 @@ mod test {
     #[test]
     fn doesnt_crash() {
         let virtual_packages =
-            VirtualPackages::detect(&VirtualPackageOverrides::default()).unwrap();
+            VirtualPackages::detect(&VirtualPackageOverrides::default(), None).unwrap();
         println!("{virtual_packages:#?}");
     }
     #[test]
@@ -1104,7 +1144,7 @@ mod test {
 
         // Test Linux 64-bit
         let linux_packages =
-            VirtualPackages::detect_for_platform(Platform::Linux64, &overrides).unwrap();
+            VirtualPackages::detect_for_platform(Platform::Linux64, &overrides, None).unwrap();
         let linux_names: Vec<String> = linux_packages
             .into_generic_virtual_packages()
             .map(|pkg| pkg.name.as_normalized().to_string())
@@ -1116,7 +1156,7 @@ mod test {
 
         // Test macOS ARM64
         let osx_packages =
-            VirtualPackages::detect_for_platform(Platform::OsxArm64, &overrides).unwrap();
+            VirtualPackages::detect_for_platform(Platform::OsxArm64, &overrides, None).unwrap();
         let osx_names: Vec<String> = osx_packages
             .into_generic_virtual_packages()
             .map(|pkg| pkg.name.as_normalized().to_string())
@@ -1127,7 +1167,7 @@ mod test {
 
         // Test Windows 64-bit
         let win_packages =
-            VirtualPackages::detect_for_platform(Platform::Win64, &overrides).unwrap();
+            VirtualPackages::detect_for_platform(Platform::Win64, &overrides, None).unwrap();
         let win_names: Vec<String> = win_packages
             .into_generic_virtual_packages()
             .map(|pkg| pkg.name.as_normalized().to_string())
@@ -1198,7 +1238,7 @@ mod test {
 
         // Case 1: Both not present - cuda_arch should be None
         let overrides = VirtualPackageOverrides::default();
-        let packages = VirtualPackages::detect(&overrides).unwrap();
+        let packages = VirtualPackages::detect(&overrides, None).unwrap();
         // If cuda is None, cuda_arch must also be None
         if packages.cuda.is_none() {
             assert!(
@@ -1214,7 +1254,7 @@ mod test {
             cuda_arch: Some(cuda_arch_override),
             ..Default::default()
         };
-        let packages = VirtualPackages::detect(&overrides).unwrap();
+        let packages = VirtualPackages::detect(&overrides, None).unwrap();
         if packages.cuda.is_none() {
             assert!(
                 packages.cuda_arch.is_none(),
@@ -1230,7 +1270,7 @@ mod test {
             cuda_arch: Some(cuda_arch_override),
             ..Default::default()
         };
-        let packages = VirtualPackages::detect(&overrides).unwrap();
+        let packages = VirtualPackages::detect(&overrides, None).unwrap();
         assert!(
             packages.cuda.is_some(),
             "cuda should be present with override"
@@ -1250,7 +1290,7 @@ mod test {
             cuda_arch: Some(cuda_arch_override),
             ..Default::default()
         };
-        let packages = VirtualPackages::detect(&overrides).unwrap();
+        let packages = VirtualPackages::detect(&overrides, None).unwrap();
         assert!(
             packages.cuda.is_none(),
             "cuda should be None with empty string override"

--- a/crates/rattler_virtual_packages/src/lib.rs
+++ b/crates/rattler_virtual_packages/src/lib.rs
@@ -673,7 +673,6 @@ impl CudaArch {
     /// * No CUDA drivers are installed
     /// * No CUDA devices are detected
     /// * Device enumeration fails
-    /// * The system is using musl libc (dynamic library loading not supported)
     pub fn current() -> Option<Self> {
         cuda::cuda_arch().map(|arch_info| Self {
             version: Version::from_str(&format!("{}.{}", arch_info.major, arch_info.minor))

--- a/py-rattler/Cargo.lock
+++ b/py-rattler/Cargo.lock
@@ -2284,6 +2284,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "http-auth"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "150fa4a9462ef926824cf4519c84ed652ca8f4fbae34cb8af045b5cbcaf98822"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "http-body"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4087,7 +4096,7 @@ dependencies = [
 
 [[package]]
 name = "rattler"
-version = "0.44.3"
+version = "0.45.0"
 dependencies = [
  "anyhow",
  "astral-reqwest-middleware",
@@ -4134,7 +4143,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_cache"
-version = "0.9.1"
+version = "0.10.0"
 dependencies = [
  "ahash",
  "anyhow",
@@ -4166,7 +4175,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_conda_types"
-version = "0.47.0"
+version = "0.47.2"
 dependencies = [
  "ahash",
  "core-foundation 0.10.1",
@@ -4206,7 +4215,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_config"
-version = "0.5.0"
+version = "0.5.2"
 dependencies = [
  "console",
  "fs-err",
@@ -4240,7 +4249,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_index"
-version = "0.30.3"
+version = "0.30.5"
 dependencies = [
  "ahash",
  "anyhow",
@@ -4278,7 +4287,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_lock"
-version = "0.31.0"
+version = "0.31.2"
 dependencies = [
  "ahash",
  "file_url",
@@ -4313,7 +4322,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_menuinst"
-version = "0.2.65"
+version = "0.2.67"
 dependencies = [
  "configparser",
  "dirs",
@@ -4342,7 +4351,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_networking"
-version = "0.28.0"
+version = "0.29.0"
 dependencies = [
  "ambient-id",
  "anyhow",
@@ -4357,9 +4366,11 @@ dependencies = [
  "dbus-secret-service-keyring-store",
  "dirs",
  "fs-err",
+ "futures",
  "getrandom 0.4.2",
  "google-cloud-auth",
  "http 1.4.2",
+ "http-auth",
  "itertools 0.14.0",
  "keyring-core",
  "netrc-rs",
@@ -4377,7 +4388,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_package_streaming"
-version = "0.26.3"
+version = "0.26.5"
 dependencies = [
  "astral-reqwest-middleware",
  "astral-tokio-tar",
@@ -4435,7 +4446,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_repodata_gateway"
-version = "0.29.4"
+version = "0.29.6"
 dependencies = [
  "ahash",
  "anyhow",
@@ -4497,7 +4508,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_s3"
-version = "0.2.3"
+version = "0.2.5"
 dependencies = [
  "aws-config",
  "aws-credential-types",
@@ -4513,7 +4524,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_shell"
-version = "0.27.5"
+version = "0.27.7"
 dependencies = [
  "anyhow",
  "enum_dispatch",
@@ -4532,7 +4543,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_solve"
-version = "7.1.2"
+version = "7.1.4"
 dependencies = [
  "futures",
  "hex",
@@ -4549,9 +4560,10 @@ dependencies = [
 
 [[package]]
 name = "rattler_virtual_packages"
-version = "3.0.0"
+version = "3.0.2"
 dependencies = [
  "archspec",
+ "dirs",
  "libloading",
  "nom",
  "once_cell",
@@ -4559,8 +4571,10 @@ dependencies = [
  "rattler_conda_types",
  "regex",
  "serde",
+ "serde_json",
  "thiserror 2.0.18",
  "tracing",
+ "windows-sys 0.61.2",
  "winver",
 ]
 

--- a/py-rattler/rattler/virtual_package/virtual_package.py
+++ b/py-rattler/rattler/virtual_package/virtual_package.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
-from typing import List
+import os
+from typing import List, Optional
 import warnings
 
 from rattler.rattler import PyVirtualPackage, PyOverride, PyVirtualPackageOverrides
@@ -197,11 +198,20 @@ class VirtualPackage:
         return VirtualPackage.detect()
 
     @staticmethod
-    def detect(overrides: VirtualPackageOverrides = VirtualPackageOverrides()) -> List[VirtualPackage]:
+    def detect(
+        overrides: VirtualPackageOverrides = VirtualPackageOverrides(),
+        cache_dir: Optional[os.PathLike[str]] = None,
+    ) -> List[VirtualPackage]:
         """
         Returns virtual packages detected for the current system with the given overrides.
+
+        If `cache_dir` is given, expensive detection results (currently CUDA) are cached in that
+        directory across processes until the next reboot.
         """
-        return [VirtualPackage._from_py_virtual_package(vp) for vp in PyVirtualPackage.detect(overrides._overrides)]
+        return [
+            VirtualPackage._from_py_virtual_package(vp)
+            for vp in PyVirtualPackage.detect(overrides._overrides, cache_dir)
+        ]
 
     def into_generic(self) -> GenericVirtualPackage:
         """

--- a/py-rattler/src/virtual_package.rs
+++ b/py-rattler/src/virtual_package.rs
@@ -1,3 +1,5 @@
+use std::path::PathBuf;
+
 use pyo3::{PyResult, pyclass, pymethods};
 use rattler_virtual_packages::{Override, VirtualPackage, VirtualPackageOverrides};
 
@@ -161,14 +163,23 @@ impl PyVirtualPackage {
     // we just warn directly from python.
     #[staticmethod]
     pub fn current() -> PyResult<Vec<Self>> {
-        Self::detect(&PyVirtualPackageOverrides::none())
+        Self::detect(&PyVirtualPackageOverrides::none(), None)
     }
 
+    /// Returns virtual packages detected for the current system with the given overrides. If
+    /// `cache_dir` is given, expensive detection results (currently CUDA) are cached there across
+    /// processes until the next reboot.
     #[staticmethod]
-    pub fn detect(overrides: &PyVirtualPackageOverrides) -> PyResult<Vec<Self>> {
-        Ok(VirtualPackage::detect(&overrides.clone().into())
-            .map(|vp| vp.iter().map(|v| v.clone().into()).collect::<Vec<_>>())
-            .map_err(PyRattlerError::from)?)
+    #[pyo3(signature = (overrides, cache_dir=None))]
+    pub fn detect(
+        overrides: &PyVirtualPackageOverrides,
+        cache_dir: Option<PathBuf>,
+    ) -> PyResult<Vec<Self>> {
+        Ok(
+            VirtualPackage::detect(&overrides.clone().into(), cache_dir.as_deref())
+                .map(|vp| vp.iter().map(|v| v.clone().into()).collect::<Vec<_>>())
+                .map_err(PyRattlerError::from)?,
+        )
     }
 
     pub fn as_generic(&self) -> PyGenericVirtualPackage {


### PR DESCRIPTION
### Description

In benchmarks, detecting the `__cuda` and `__cuda_arch` virtual packages could take a long time, particularly on Windows, because every detection initialized the NVIDIA driver and connected to the GPU.

This PR makes CUDA detection fast:

- The CUDA driver version is now read directly from the driver library without initializing it, which makes `__cuda` detection nearly instant.
- Detecting `__cuda_arch` still requires connecting to the GPU, so the combined detection result is now cached on disk and reused until it becomes invalid. The cache is invalidated by a reboot or by a driver update, so a change in the installed driver or hardware is always picked up.
- Callers control where the cache lives through a new optional `cache_dir` argument on the detection functions. Passing `None` disables the on-disk cache. This is a breaking change to the detection API.
- The Python bindings expose the new `cache_dir` argument on `VirtualPackage.detect`.

The first detection after a boot pays a single driver initialization. Every run after that reads a small cache file instead of connecting to the GPU.

Along the way this also fixes several issues in the detection itself:

- Detection now goes through NVML instead of libcuda, so the results are no longer influenced by the `CUDA_VISIBLE_DEVICES` environment variable. Previously an environment where this variable was set, for example under a job scheduler or in CI, could report wrong or missing `__cuda` and `__cuda_arch` packages.
- `__cuda_arch` is now also detected on musl systems, where it was previously always absent.
- `__cuda` can now be detected even when the driver fails to initialize, for example when a GPU is in a bad state, because the version query no longer depends on initialization.

### How Has This Been Tested?

- Unit tests cover the cache roundtrip, invalidation after a reboot, invalidation after a driver update, and the new musl detection path, next to the existing detection tests. Run them with `pixi run -- cargo nextest run -p rattler_virtual_packages`.
- `cargo clippy` and `cargo fmt` pass for `rattler_virtual_packages` and `rattler-bin`, the crate compiles for `x86_64-unknown-linux-musl`, and `cargo check` passes for `py-rattler`.
- The detection degrades gracefully on machines without a GPU, but the speedup has not been benchmarked on real GPU hardware yet. Verifying the timings on a Windows machine with an NVIDIA GPU is recommended.

### AI Disclosure
- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.

Tools: Claude Code

### Checklist:
- [ ] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added sufficient tests to cover my changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HD1ZUoiAETSKFn9Kj6JkxQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01HD1ZUoiAETSKFn9Kj6JkxQ)_