### PR TITLE
fix(repodata_gateway): test remote run_exports against a local server

### DIFF
--- a/crates/rattler_repodata_gateway/src/gateway/mod.rs
+++ b/crates/rattler_repodata_gateway/src/gateway/mod.rs
@@ -1404,26 +1404,37 @@ mod test {
 
     #[tokio::test]
     async fn test_ensure_run_exports_remote_conda_forge() {
-        // conda-forge's sharded repodata now embeds `run_exports` directly in the
-        // records. Disable sharded repodata so that the records are fetched from
-        // `repodata.json` (which does not contain `run_exports`). This ensures the
-        // records start out without `run_exports` and allows us to exercise
-        // `ensure_run_exports`.
-        let gateway = Gateway::builder()
-            .with_channel_config(crate::ChannelConfig {
-                default: SourceConfig {
-                    sharded_enabled: false,
-                    ..SourceConfig::default()
-                },
-                ..crate::ChannelConfig::default()
-            })
-            .finish();
+        // Serve a copy of the pinned conda-forge snapshot over HTTP so this test
+        // exercises the remote code path of `ensure_run_exports` without
+        // depending on live conda-forge data (which drifts and previously broke
+        // the record count assertion).
+        let channel_dir = tempfile::tempdir().unwrap();
+        for subdir in ["linux-64", "noarch"] {
+            let repodata = tools::fetch_test_conda_forge_repodata_async(subdir)
+                .await
+                .unwrap();
+            let subdir_dir = channel_dir.path().join(subdir);
+            std::fs::create_dir_all(&subdir_dir).unwrap();
+
+            // Remove the `base_url` so that the record urls (and with that the
+            // `run_exports.json` lookups) resolve relative to the local server
+            // instead of conda.anaconda.org.
+            let mut repodata: serde_json::Value =
+                serde_json::from_str(&std::fs::read_to_string(repodata).unwrap()).unwrap();
+            repodata["info"].as_object_mut().unwrap().remove("base_url");
+            std::fs::write(
+                subdir_dir.join("repodata.json"),
+                serde_json::to_string(&repodata).unwrap(),
+            )
+            .unwrap();
+        }
+
+        let server = SimpleChannelServer::new(channel_dir.path()).await;
+        let gateway = Gateway::new();
 
         let records = gateway
             .query(
-                vec![Channel::from_url(
-                    Url::parse("https://conda.anaconda.org/conda-forge/").unwrap(),
-                )],
+                vec![server.channel()],
                 vec![Platform::Linux64, Platform::NoArch],
                 vec![MatchSpec::from_str("openssl=3.*=*_1", Lenient).unwrap()].into_iter(),
             )
@@ -1432,7 +1443,7 @@ mod test {
             .unwrap();
 
         let total_records: usize = records.iter().map(RepoData::len).sum();
-        assert_eq!(total_records, 19);
+        assert_eq!(total_records, 3);
 
         let mut repodata_records = records
             .iter()
@@ -1441,12 +1452,55 @@ mod test {
 
         assert!(run_exports_missing(&repodata_records));
 
+        // Serve a `run_exports.json` that covers the matched records. The run
+        // exports carry a marker value that the real packages do not contain, so
+        // we can verify below that they were fetched from the served file rather
+        // than extracted from the packages themselves.
+        for subdir in ["linux-64", "noarch"] {
+            let mut packages = serde_json::Map::new();
+            let mut conda_packages = serde_json::Map::new();
+            for record in repodata_records
+                .iter()
+                .filter(|record| record.package_record.subdir == subdir)
+            {
+                let file_name = record.identifier.to_file_name();
+                let entry = serde_json::json!({
+                    "run_exports": { "weak": ["from-run-exports-json"] }
+                });
+                if file_name.ends_with(".conda") {
+                    conda_packages.insert(file_name, entry);
+                } else {
+                    packages.insert(file_name, entry);
+                }
+            }
+            let run_exports = serde_json::json!({
+                "packages": packages,
+                "packages.conda": conda_packages,
+            });
+            std::fs::write(
+                channel_dir.path().join(subdir).join("run_exports.json"),
+                serde_json::to_string(&run_exports).unwrap(),
+            )
+            .unwrap();
+        }
+
         gateway
             .ensure_run_exports(repodata_records.iter_mut(), None)
             .await
             .unwrap();
 
         assert!(run_exports_in_place(&repodata_records));
+
+        // The run exports must originate from the served `run_exports.json`, not
+        // from the package download fallback.
+        for record in &repodata_records {
+            assert_eq!(
+                record.package_record.run_exports.as_ref().unwrap().weak,
+                vec!["from-run-exports-json".to_string()],
+                "run_exports of {} should come from the served run_exports.json",
+                record.identifier
+            );
+        }
     }
 
     /// A mock `RepoDataSource` for testing custom source functionality.


### PR DESCRIPTION
### Description

`test_ensure_run_exports_remote_conda_forge` queried live conda-forge and asserted that exactly 19 records match `openssl=3.*=*_1`. conda-forge published new matching openssl builds, so the query now returns 21 records and the test fails on every branch, including main.

The purpose of the test is to verify that `ensure_run_exports` can fetch missing `run_exports` through the remote (HTTP) code path. This PR keeps that coverage but removes the dependency on live data:

- The test serves a copy of the pinned conda-forge snapshot (the same fixture the local variant of the test uses) through `SimpleChannelServer`, the local HTTP server already used by many other tests in this crate.
- The `base_url` is stripped from the served `repodata.json` so the record urls resolve to the local server instead of conda.anaconda.org. Previously the run exports lookup silently went to the real CDN.
- The server also serves a `run_exports.json` whose entries carry a marker value that real packages do not contain. The test asserts the marker comes back, proving the run exports were fetched from the served `run_exports.json` rather than through the package download fallback. This path was not covered before: the old test only ever exercised the fallback because live conda-forge serves records without a matching `run_exports.json` entry for this fixture setup.

The out-of-sync fallback path remains covered by the existing `test_ensure_run_exports_fallback_when_out_of_sync`.

### How Has This Been Tested?

- All three `ensure_run_exports` tests pass locally: `cargo test -p rattler_repodata_gateway --all-features ensure_run_exports`.
- `cargo fmt` and `cargo clippy --all-features` are clean for the crate.

### AI Disclosure
- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.

Tools: Claude Code

### Checklist:
- [ ] I have performed a self-review of my own code
- [x] I have added sufficient tests to cover my changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HD1ZUoiAETSKFn9Kj6JkxQ